### PR TITLE
Fix PEP8 voilations in GettingStarted

### DIFF
--- a/docs/GettingStart.md
+++ b/docs/GettingStart.md
@@ -33,7 +33,7 @@
 ```
 <metadata1>\t<v11>|<v12>|<v13>|
 <metadata2>\t<v21>|<v22>|<v23>|
-... 
+...
 ```
 where each line represents a vector with its metadata and its value separated by a tab space. Each dimension of a vector is separated by | or use --delimiter to define the separator.
 
@@ -49,7 +49,7 @@ where each line represents the K nearest neighbors of a query separated by a bla
 ```bash
 Usage:
 ./Server [options]
-Options: 
+Options:
   -m, --mode <value>              Service mode, interactive or socket.
   -c, --config <value>            Configure file of the index
 
@@ -112,7 +112,6 @@ Port=8010
 ### **Python Support**
 > Singlebox PythonWrapper
  ```python
- 
 import SPTAG
 import numpy as np
 
@@ -120,37 +119,42 @@ n = 100
 k = 3
 r = 3
 
-def testBuild(algo, distmethod, x, out):
+
+def test_build(algo, distmethod, x, out):
     i = SPTAG.AnnIndex(algo, 'Float', x.shape[1])
     i.SetBuildParam("NumberOfThreads", '4')
     i.SetBuildParam("DistCalcMethod", distmethod)
     ret = i.Build(x.tobytes(), x.shape[0])
     i.Save(out)
 
-def testBuildWithMetaData(algo, distmethod, x, s, out):
+
+def test_build_with_metadata(algo, distmethod, x, s, out):
     i = SPTAG.AnnIndex(algo, 'Float', x.shape[1])
     i.SetBuildParam("NumberOfThreads", '4')
     i.SetBuildParam("DistCalcMethod", distmethod)
     if i.BuildWithMetaData(x.tobytes(), s, x.shape[0]):
         i.Save(out)
 
-def testSearch(index, q, k):
+
+def test_search(index, q, k):
     j = SPTAG.AnnIndex.Load(index)
     for t in range(q.shape[0]):
         result = j.Search(q[t].tobytes(), k)
-        print (result[0]) # ids
-        print (result[1]) # distances
+        print(result[0]) # ids
+        print(result[1]) # distances
 
-def testSearchWithMetaData(index, q, k):
+
+def test_search_with_metadata(index, q, k):
     j = SPTAG.AnnIndex.Load(index)
     j.SetSearchParam("MaxCheck", '1024')
     for t in range(q.shape[0]):
         result = j.SearchWithMetaData(q[t].tobytes(), k)
-        print (result[0]) # ids
-        print (result[1]) # distances
-        print (result[2]) # metadata
+        print(result[0]) # ids
+        print(result[1]) # distances
+        print(result[2]) # metadata
 
-def testAdd(index, x, out, algo, distmethod):
+
+def test_add(index, x, out, algo, distmethod):
     if index != None:
         i = SPTAG.AnnIndex.Load(index)
     else:
@@ -160,7 +164,8 @@ def testAdd(index, x, out, algo, distmethod):
     if i.Add(x.tobytes(), x.shape[0]):
         i.Save(out)
 
-def testAddWithMetaData(index, x, s, out, algo, distmethod):
+
+def test_add_with_metadata(index, x, s, out, algo, distmethod):
     if index != None:
         i = SPTAG.AnnIndex.Load(index)
     else:
@@ -171,49 +176,53 @@ def testAddWithMetaData(index, x, s, out, algo, distmethod):
     if i.AddWithMetaData(x.tobytes(), s, x.shape[0]):
         i.Save(out)
 
-def testDelete(index, x, out):
+
+def test_delete(index, x, out):
     i = SPTAG.AnnIndex.Load(index)
     ret = i.Delete(x.tobytes(), x.shape[0])
-    print (ret)
+    print(ret)
     i.Save(out)
-    
-def Test(algo, distmethod):
+
+
+def test(algo, distmethod):
     x = np.ones((n, 10), dtype=np.float32) * np.reshape(np.arange(n, dtype=np.float32), (n, 1))
     q = np.ones((r, 10), dtype=np.float32) * np.reshape(np.arange(r, dtype=np.float32), (r, 1)) * 2
     m = ''
     for i in range(n):
         m += str(i) + '\n'
 
-    print ("Build.............................")
-    testBuild(algo, distmethod, x, 'testindices')
-    testSearch('testindices', q, k)
-    print ("Add.............................")
-    testAdd('testindices', x, 'testindices', algo, distmethod)
-    testSearch('testindices', q, k)
-    print ("Delete.............................")
-    testDelete('testindices', q, 'testindices')
-    testSearch('testindices', q, k)
+    print("Build.............................")
+    test_build(algo, distmethod, x, 'testindices')
+    test_search('testindices', q, k)
+    print("Add.............................")
+    test_add('testindices', x, 'testindices', algo, distmethod)
+    test_search('testindices', q, k)
+    print("Delete.............................")
+    test_delete('testindices', q, 'testindices')
+    test_search('testindices', q, k)
 
-    print ("AddWithMetaData.............................")
-    testAddWithMetaData(None, x, m, 'testindices', algo, distmethod)
-    print ("Delete.............................")
-    testSearchWithMetaData('testindices', q, k)
-    testDelete('testindices', q, 'testindices')
-    testSearchWithMetaData('testindices', q, k)
+    print("AddWithMetaData.............................")
+    test_add_with_metadata(None, x, m, 'testindices', algo, distmethod)
+    print("Delete.............................")
+    test_search_with_metadata('testindices', q, k)
+    test_delete('testindices', q, 'testindices')
+    test_search_with_metadata('testindices', q, k)
+
 
 if __name__ == '__main__':
-    Test('BKT', 'L2')
-    Test('KDT', 'L2')
-
+    test('BKT', 'L2')
+    test('KDT', 'L2')
  ```
 
  > Python Client Wrapper, Suppose there is a sever run at 127.0.0.1:8000 serving ten-dimensional vector datasets:
  ```python
-import SPTAGClient
-import numpy as np
 import time
 
-def testSPTAGClient():
+import SPTAGClient
+import numpy as np
+
+
+def test_sptag_client():
     index = SPTAGClient.AnnClient('127.0.0.1', '8100')
     while not index.IsConnected():
         time.sleep(1)
@@ -222,13 +231,13 @@ def testSPTAGClient():
     q = np.ones((10, 10), dtype=np.float32)
     for t in range(q.shape[0]):
         result = index.Search(q[t].tobytes(), 6, 'Float', False)
-        print (result[0])
-        print (result[1])
+        print(result[0])
+        print(result[1])
+
 
 if __name__ == '__main__':
-    testSPTAGClient()
+    test_sptag_client()
 
  ```
-  
-  
-  
+
+


### PR DESCRIPTION
The getting started guide python code has multiple [PEP8](https://www.python.org/dev/peps/pep-0008/) errors in it, which I've fixed.