### PR TITLE
Minor rework of SpinLock class for making it more efficient on Unlock()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ dkms.conf
 /Wrappers/inc/AnnIndex.java
 /Wrappers/inc/AnnClient.java
 /AnnService.users - Copy.props
+/.vs

--- a/AnnService/inc/Helper/Concurrent.h
+++ b/AnnService/inc/Helper/Concurrent.h
@@ -20,19 +20,19 @@ namespace Concurrent
 class SpinLock
 {
 public:
-	SpinLock() = default;
+    SpinLock() = default;
 
-	void Lock() noexcept 
-	{
-		while (m_lock.test_and_set(std::memory_order_acquire))
-		{
-		}
-	}
+    void Lock() noexcept 
+    {
+        while (m_lock.test_and_set(std::memory_order_acquire))
+        {
+        }
+    }
 
-	void Unlock() noexcept 
-	{
-		m_lock.clear(std::memory_order_release);
-	}
+    void Unlock() noexcept 
+    {
+        m_lock.clear(std::memory_order_release);
+    }
 
     SpinLock(const SpinLock&) = delete;
     SpinLock& operator = (const SpinLock&) = delete;

--- a/AnnService/inc/Helper/Concurrent.h
+++ b/AnnService/inc/Helper/Concurrent.h
@@ -4,12 +4,11 @@
 #ifndef _SPTAG_HELPER_CONCURRENT_H_
 #define _SPTAG_HELPER_CONCURRENT_H_
 
-#include <cstdint>
-#include <cstddef> 
+
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <memory>
+
 
 namespace SPTAG
 {
@@ -21,17 +20,25 @@ namespace Concurrent
 class SpinLock
 {
 public:
-    SpinLock();
-    ~SpinLock();
+	SpinLock() = default;
 
-    void Lock();
-    void Unlock();
+	void Lock() noexcept 
+	{
+		while (m_lock.test_and_set(std::memory_order_acquire))
+		{
+		}
+	}
+
+	void Unlock() noexcept 
+	{
+		m_lock.clear(std::memory_order_release);
+	}
 
     SpinLock(const SpinLock&) = delete;
     SpinLock& operator = (const SpinLock&) = delete;
 
 private:
-    std::atomic_flag m_lock;
+    std::atomic_flag m_lock = ATOMIC_FLAG_INIT;
 };
 
 

--- a/AnnService/src/Helper/Concurrent.cpp
+++ b/AnnService/src/Helper/Concurrent.cpp
@@ -6,35 +6,6 @@
 using namespace SPTAG;
 using namespace SPTAG::Helper::Concurrent;
 
-
-SpinLock::SpinLock()
-    : m_lock()
-{
-    m_lock.clear();
-}
-
-
-SpinLock::~SpinLock()
-{
-}
-
-
-void
-SpinLock::Lock()
-{
-    while (m_lock.test_and_set(std::memory_order_acquire))
-    {
-    }
-}
-
-
-void
-SpinLock::Unlock()
-{
-    m_lock.clear();
-}
-
-
 WaitSignal::WaitSignal()
     : m_isWaiting(false),
       m_unfinished(0)


### PR DESCRIPTION
+ atomic_flag is initialized using the recommended ATOMIC_FLAG_INIT
+ Unlock() function clears the atomic_flag using more efficient std::memory_order_acquire
+ Unlock() and Lock() methods are now both noexcept
+ Removed unnecessary include files