### PR TITLE
add Dockerfile for building SPTAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+WORKDIR /app
+COPY CMakeLists.txt ./
+COPY AnnService ./AnnService/
+COPY Test ./Test/
+COPY Wrappers ./Wrappers/
+
+RUN apt-get update && apt-get -y install wget build-essential libtbb-dev \
+    # remove the following if you don't want to build the wrappers
+    openjdk-8-jdk python3-pip swig
+
+# latest cmake
+RUN wget "https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.tar.gz" -q -O - \
+        | tar -xz --strip-components=1 -C /usr/local
+
+# specific version of boost
+RUN wget "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz" -q -O - \
+        | tar -xz && \
+        cd boost_1_67_0 && \
+        ./bootstrap.sh && \
+        ./b2 install && \
+        # update ld cache so it finds boost in /usr/local/lib
+        ldconfig && \
+        cd .. && rm -rf boost_1_67_0
+
+# build
+RUN mkdir build && cd build && cmake .. && make && cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,6 @@ RUN wget "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar
 
 # build
 RUN mkdir build && cd build && cmake .. && make && cd ..
+
+# so python can find the SPTAG module
+ENV PYTHONPATH=/app/Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install wget build-essential libtbb-dev \
     # remove the following if you don't want to build the wrappers
     openjdk-8-jdk python3-pip swig
 
-# latest cmake
+# cmake >= 3.12 is required
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.tar.gz" -q -O - \
         | tar -xz --strip-components=1 -C /usr/local
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Compiling the ALL_BUILD project in the Visual Studio (at least 2015) will genera
 ```bash
 docker build -t sptag .
 ```
-Will build a docker container with binaries in `/app/Release`
+Will build a docker container with binaries in `/app/Release/`
 
 ### **Verify** 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ cd build && cmake -A x64 ..
 It will generate a SPTAGLib.sln in the build directory. 
 Compiling the ALL_BUILD project in the Visual Studio (at least 2015) will generate a Release directory which contains all the build targets.
 
+> Using Docker:
+```bash
+docker build -t sptag .
+```
+Will build a docker container with binaries in `/app/Release`
+
 ### **Verify** 
 
 Run the test (or Test.exe) in the Release folder to verify all the tests have passed.


### PR DESCRIPTION
Add a Dockerfile for creating a docker container which can be used to build and run SPTAG on Mac OS X (and other OSes and distributions)