### PR TITLE
gcc 4.8 compile error

### DIFF
--- a/AnnService/inc/Core/Common/QueryResultSet.h
+++ b/AnnService/inc/Core/Common/QueryResultSet.h
@@ -17,7 +17,7 @@ inline bool operator < (const BasicResult& lhs, const BasicResult& rhs)
 }
 
 
-inline bool Compare(BasicResult& lhs, BasicResult& rhs)
+inline bool Compare(const BasicResult& lhs, const BasicResult& rhs)
 {
     return ((lhs.Dist < rhs.Dist) || ((lhs.Dist == rhs.Dist) && (lhs.VID < rhs.VID)));
 }


### PR DESCRIPTION
stl sort Compare function definition modify.

In file included from /usr/include/c++/4.8.2/algorithm:62:0,
                 from /root/code/SPTAG/AnnService/inc/Core/BKT/../Common/CommonUtils.h:14,
                 from /root/code/SPTAG/AnnService/inc/Core/BKT/Index.h:10,
                 from /root/code/SPTAG/AnnService/src/Core/BKT/BKTIndex.cpp:4:
/usr/include/c++/4.8.2/bits/stl_algo.h: In instantiation of '_RandomAccessIterator std::__unguarded_partition(_RandomAccessIterator, _RandomAccessIterator, const _Tp&, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<SPTAG::BasicResult*, std::vector<SPTAG::BasicResult> >; _Tp = SPTAG::BasicResult; _Compare = bool (*)(SPTAG::BasicResult&, SPTAG::BasicResult&)]':
/usr/include/c++/4.8.2/bits/stl_algo.h:2296:78:   required from '_RandomAccessIterator std::__unguarded_partition_pivot(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<SPTAG::BasicResult*, std::vector<SPTAG::BasicResult> >; _Compare = bool (*)(SPTAG::BasicResult&, SPTAG::BasicResult&)]'
/usr/include/c++/4.8.2/bits/stl_algo.h:2337:62:   required from 'void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<SPTAG::BasicResult*, std::vector<SPTAG::BasicResult> >; _Size = long int; _Compare = bool (*)(SPTAG::BasicResult&, SPTAG::BasicResult&)]'
/usr/include/c++/4.8.2/bits/stl_algo.h:5499:44:   required from 'void std::sort(_RAIter, _RAIter, _Compare) [with _RAIter = __gnu_cxx::__normal_iterator<SPTAG::BasicResult*, std::vector<SPTAG::BasicResult> >; _Compare = bool (*)(SPTAG::BasicResult&, SPTAG::BasicResult&)]'
/root/code/SPTAG/AnnService/inc/Core/BKT/../Common/NeighborhoodGraph.h:246:80:   required from 'void SPTAG::COMMON::NeighborhoodGraph::PartitionByTptree(SPTAG::VectorIndex*, std::vector<int>&, int, int, std::vector<std::pair<int, int> >&) [with T = signed char]'
/root/code/SPTAG/AnnService/inc/Core/BKT/../Common/NeighborhoodGraph.h:72:114:   required from 'void SPTAG::COMMON::NeighborhoodGraph::BuildGraph(SPTAG::VectorIndex*, const std::unordered_map<int, int>*) [with T = signed char]'
/root/code/SPTAG/AnnService/src/Core/BKT/BKTIndex.cpp:150:13:   required from 'SPTAG::ErrorCode SPTAG::BKT::Index<T>::BuildIndex(const void*, int, int) [with T = signed char]'
/root/code/SPTAG/AnnService/inc/Core/DefinitionList.h:6:1:   required from here
/usr/include/c++/4.8.2/bits/stl_algo.h:2263:35: error: invalid initialization of reference of type 'SPTAG::BasicResult&' from expression of type 'const SPTAG::BasicResult'
    while (__comp(*__first, __pivot))
                                   ^
/usr/include/c++/4.8.2/bits/stl_algo.h:2266:34: error: invalid initialization of reference of type 'SPTAG::BasicResult&' from expression of type 'const SPTAG::BasicResult'
    while (__comp(__pivot, *__last))
                                  ^
make[2]: *** [AnnService/CMakeFiles/SPTAGLib.dir/src/Core/BKT/BKTIndex.cpp.o] Error 1
make[1]: *** [AnnService/CMakeFiles/SPTAGLib.dir/all] Error 2