### PR TITLE
 Add new --append option to IndexBuilder to support adding new items to an existing index

### DIFF
--- a/AnnService/inc/IndexBuilder/Options.h
+++ b/AnnService/inc/IndexBuilder/Options.h
@@ -29,6 +29,8 @@ public:
 
     std::string m_vectorDelimiter;
 
+	bool m_append;
+
     SPTAG::VectorValueType m_inputValueType;
 
     std::string m_inputFiles;

--- a/AnnService/inc/IndexBuilder/Options.h
+++ b/AnnService/inc/IndexBuilder/Options.h
@@ -29,7 +29,7 @@ public:
 
     std::string m_vectorDelimiter;
 
-	bool m_append;
+    bool m_append;
 
     SPTAG::VectorValueType m_inputValueType;
 

--- a/AnnService/src/IndexBuilder/Options.cpp
+++ b/AnnService/src/IndexBuilder/Options.cpp
@@ -22,7 +22,8 @@ BuilderOptions::BuilderOptions()
     AddRequiredOption(m_inputFiles, "-i", "--input", "Input raw data.");
     AddRequiredOption(m_outputFolder, "-o", "--outputfolder", "Output folder.");
     AddRequiredOption(m_indexAlgoType, "-a", "--algo", "Index Algorithm type.");
-    AddOptionalOption(m_builderConfigFile, "-c", "--config", "Config file for builder.");
+	AddOptionalOption(m_builderConfigFile, "-c", "--config", "Config file for builder.");
+	AddOptionalOption(m_append, "-p", "--append", "Append to existing index.");
 }
 
 

--- a/AnnService/src/IndexBuilder/Options.cpp
+++ b/AnnService/src/IndexBuilder/Options.cpp
@@ -22,8 +22,8 @@ BuilderOptions::BuilderOptions()
     AddRequiredOption(m_inputFiles, "-i", "--input", "Input raw data.");
     AddRequiredOption(m_outputFolder, "-o", "--outputfolder", "Output folder.");
     AddRequiredOption(m_indexAlgoType, "-a", "--algo", "Index Algorithm type.");
-	AddOptionalOption(m_builderConfigFile, "-c", "--config", "Config file for builder.");
-	AddOptionalOption(m_append, "-p", "--append", "Append to existing index.");
+    AddOptionalOption(m_builderConfigFile, "-c", "--config", "Config file for builder.");
+    AddOptionalOption(m_append, "-p", "--append", "Append to existing index.");
 }
 
 

--- a/AnnService/src/IndexBuilder/main.cpp
+++ b/AnnService/src/IndexBuilder/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
         inputStream.read(vecBuf, totalRecordVectorBytes);
         inputStream.close();
 
-        p_vectorSet = std::make_shared<BasicVectorSet>(*new BasicVectorSet(vectorSet, options->m_inputValueType, col, row));
+        p_vectorSet.reset(new BasicVectorSet(vectorSet, options->m_inputValueType, col, row));
         
         if (files.size() >= 3) {
             p_metaSet.reset(new FileMetadataSet(files[1], files[2]));

--- a/AnnService/src/IndexBuilder/main.cpp
+++ b/AnnService/src/IndexBuilder/main.cpp
@@ -55,8 +55,8 @@ int main(int argc, char* argv[])
         indexBuilder->SetParameter(iter.first.c_str(), iter.second.c_str());
     }
 
-	std::shared_ptr<VectorSet> p_vectorSet = nullptr;
-	std::shared_ptr<MetadataSet> p_metaSet = nullptr;
+    std::shared_ptr<VectorSet> p_vectorSet = nullptr;
+    std::shared_ptr<MetadataSet> p_metaSet = nullptr;
 
     if (options->m_inputFiles.find("BIN:") == 0) {
         std::vector<std::string> files = SPTAG::Helper::StrUtils::SplitString(options->m_inputFiles.substr(4), ",");
@@ -88,20 +88,20 @@ int main(int argc, char* argv[])
             exit(1);
         }
 
-		p_vectorSet = vectorReader->GetVectorSet();
-		p_metaSet = vectorReader->GetMetadataSet();
+        p_vectorSet = vectorReader->GetVectorSet();
+        p_metaSet = vectorReader->GetMetadataSet();
     }
 
-	ErrorCode code;
-	std::shared_ptr<SPTAG::VectorIndex> vecIndex;
-	if (options->m_append && ErrorCode::Success == indexBuilder->LoadIndex(options->m_outputFolder, vecIndex) && nullptr != vecIndex) {
-		code = vecIndex->AddIndex(p_vectorSet, p_metaSet);
-		indexBuilder = vecIndex;
-	}
-	else {
-		code = indexBuilder->BuildIndex(p_vectorSet, p_metaSet);
-	}
-	indexBuilder->SaveIndex(options->m_outputFolder);
+    ErrorCode code;
+    std::shared_ptr<SPTAG::VectorIndex> vecIndex;
+    if (options->m_append && ErrorCode::Success == indexBuilder->LoadIndex(options->m_outputFolder, vecIndex) && nullptr != vecIndex) {
+        code = vecIndex->AddIndex(p_vectorSet, p_metaSet);
+        indexBuilder = vecIndex;
+    }
+    else {
+        code = indexBuilder->BuildIndex(p_vectorSet, p_metaSet);
+    }
+    indexBuilder->SaveIndex(options->m_outputFolder);
 
     if (ErrorCode::Success != code)
     {

--- a/docs/GettingStart.md
+++ b/docs/GettingStart.md
@@ -11,6 +11,7 @@
   -o, --outputfolder <value>    Output folder, required.
   -a, --algo <value>            Index Algorithm type (e.g. BKT, KDT), required.
 
+  -p, --append <true|false>     Indicate whether the data should be appended to an existing index, if one exists.
   -t, --thread <value>          Thread Number, default is 32.
   --delimiter <value>           Vector delimiter, default is |.
   Index.<ArgName>=<ArgValue>    Set the algorithm parameter ArgName with value ArgValue.


### PR DESCRIPTION
From what I can tell, there's no ability with the CLI to append data onto an existing index; running IndexBuilder starts afresh.

This PR adds an `--append` parameter to IndexBuilder, which attempts to load an existing index, and calls the `VectorIndex::AddIndex` function if it already exists.

I'm pretty new to C++ (from C#, so look out), so there are some changes I'm not totally confident about. But it seems pretty simple.