### PR TITLE
Fix wrong port number

### DIFF
--- a/docs/GettingStart.md
+++ b/docs/GettingStart.md
@@ -216,7 +216,7 @@ import numpy as np
 import time
 
 def testSPTAGClient():
-    index = SPTAGClient.AnnClient('127.0.0.1', '8100')
+    index = SPTAGClient.AnnClient('127.0.0.1', '8000')
     while not index.IsConnected():
         time.sleep(1)
     index.SetTimeoutMilliseconds(18000)


### PR DESCRIPTION
Tutorial states the server running at 127.0.0.1:8000 yet the code is for port 8100.