### PR TITLE
Add support for signed int8 datatype for gpuindexbuilder

### DIFF
--- a/AnnService/inc/Core/Common/BKTree.h
+++ b/AnnService/inc/Core/Common/BKTree.h
@@ -168,6 +168,8 @@ namespace SPTAG
                     m_pTreeRoots.emplace_back((SizeType)localindices.size());
                     std::cout << "Start to build BKTree " << i + 1 << std::endl;
 
+time_t start_t = clock();
+
                     ss.push(BKTStackItem(m_pTreeStart[i], 0, (SizeType)localindices.size()));
                     while (!ss.empty()) {
                         BKTStackItem item = ss.top(); ss.pop();
@@ -205,6 +207,8 @@ namespace SPTAG
                         }
                         m_pTreeRoots[item.index].childEnd = (SizeType)m_pTreeRoots.size();
                     }
+time_t end_t = clock();
+printf("Time to build BKT:%lf\n", (double)(end_t-start_t)/CLOCKS_PER_SEC);
                     m_pTreeRoots.emplace_back(-1);
                     std::cout << i + 1 << " BKTree built, " << m_pTreeRoots.size() - m_pTreeStart[i] << " " << localindices.size() << std::endl;
                 }

--- a/AnnService/inc/Core/Common/cuda/TPtree.hxx
+++ b/AnnService/inc/Core/Common/cuda/TPtree.hxx
@@ -282,6 +282,19 @@ __device__ KEY_T weighted_val(Point<uint8_t,SUMTYPE,Dim> point, KEY_T* weights, 
   return val;
 }
 
+template<typename T, typename KEY_T, typename SUMTYPE, int Dim, int PART_DIMS>
+__device__ KEY_T weighted_val(Point<int8_t,SUMTYPE,Dim> point, KEY_T* weights, int* dims) {
+
+  KEY_T val=0.0;
+  for(int i=0; i<PART_DIMS/4; ++i) {
+    val += (KEY_T)(weights[i*4] * (int8_t)(point.coords[i] & 0x000000FF));
+    val += (KEY_T)(weights[i*4+1] *(int8_t)((point.coords[i] & 0x0000FF00) >> 8));
+    val += (KEY_T)(weights[i*4+2] *(int8_t)((point.coords[i] & 0x00FF0000) >> 16));
+    val += (KEY_T)(weights[i*4+3] *(int8_t)((point.coords[i] & 0xFF000000) >> 24));
+  }
+  return val;
+}
+
 
 template<typename T, typename KEY_T, typename SUMTYPE, int Dim, int PART_DIMS>
 __global__ void find_level_sum(Point<T,SUMTYPE,Dim>* points, KEY_T* weights, int* partition_dims, int* node_ids, KEY_T* split_keys, int* node_sizes, int N, int nodes_on_level) {

--- a/GPUSupport/CMakeLists.txt
+++ b/GPUSupport/CMakeLists.txt
@@ -10,16 +10,12 @@ if (CUDA_FOUND)
         set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -fopenmp -std=c++14 -Xptxas -O3 --use_fast_math 
         -gencode arch=compute_70,code=sm_70 
         -gencode arch=compute_61,code=sm_61
-        -gencode arch=compute_60,code=sm_60
-        -gencode arch=compute_52,code=sm_52
-        -gencode arch=compute_50,code=sm_50" )
+        -gencode arch=compute_60,code=sm_60" )
     elseif(WIN32)
         set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler /openmp -Xcompiler /std:c++14 -Xcompiler /Zc:__cplusplus --use_fast_math
         -gencode arch=compute_70,code=sm_70 
         -gencode arch=compute_61,code=sm_61
-        -gencode arch=compute_60,code=sm_60
-        -gencode arch=compute_52,code=sm_52
-        -gencode arch=compute_50,code=sm_50" )
+        -gencode arch=compute_60,code=sm_60" )
     endif()
    
     message (STATUS "CUDA_NVCC_FLAGS:" ${CUDA_NVCC_FLAGS})


### PR DESCRIPTION
Added support for signed int8 vectors for GPU construction.  For compute capability >= 6.1, uses optimizations for cosine distance comparator for int8 and uint8 types. 

- Currently has an issue with lower accuracy for signed int8 cosine distance on compute capability < 6.1.
- Tested on Linux and Windows, GPU RNG construction achieves good perf/accuracy on large datasets (with and without batches).
- BKT construction on CPU seems to be slow, especially for large datasets, regardless of NumberOfThreads used.