### PR TITLE
Add up-to-date Dockerfile for NVIDIA CUDA

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,18 @@
+FROM nvidia/cuda:11.0-devel-ubuntu20.04
+WORKDIR /app
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y install build-essential \
+    swig cmake git \
+    libboost-filesystem-dev libboost-test-dev libboost-serialization-dev libboost-regex-dev libboost-serialization-dev libboost-regex-dev libboost-thread-dev libboost-system-dev
+
+ENV PYTHONPATH=/app/Release
+
+COPY CMakeLists.txt ./
+COPY AnnService ./AnnService/
+COPY Test ./Test/
+COPY Wrappers ./Wrappers/
+COPY GPUSupport ./GPUSupport/
+
+RUN mkdir build && cd build && cmake .. && make -j && cd ..


### PR DESCRIPTION
Add up-to-date Dockerfile for NVIDIA CUDA.

No need to build third-party dependencies.