### PR TITLE
Remove GPU number selection bug

### DIFF
--- a/AnnService/inc/Core/BKT/ParameterDefinitionList.h
+++ b/AnnService/inc/Core/BKT/ParameterDefinitionList.h
@@ -32,7 +32,6 @@ DefineBKTParameter(m_pGraph.m_iGPURefineSteps, int, 0, "GPURefineSteps") // Step
 DefineBKTParameter(m_pGraph.m_iGPURefineDepth, int, 30, "GPURefineDepth") // Depth of graph search for refinement
 DefineBKTParameter(m_pGraph.m_iGPULeafSize, int, 500, "GPULeafSize")
 DefineBKTParameter(m_pGraph.m_iGPUBatches, int, 1, "GPUBatches")
-DefineBKTParameter(m_pGraph.m_iGPUNum, int, 0, "GPUNum")
 
 DefineBKTParameter(m_iNumberOfThreads, int, 1L, "NumberOfThreads")
 DefineBKTParameter(m_iDistCalcMethod, SPTAG::DistCalcMethod, SPTAG::DistCalcMethod::Cosine, "DistCalcMethod")

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -48,7 +48,6 @@ namespace SPTAG
                                  m_iGPURefineDepth(2),
                                  m_iGPULeafSize(500),
                                  m_iGPUBatches(1),
-                                 m_iGPUNum(0)
             {}
 
             ~NeighborhoodGraph() {}
@@ -106,7 +105,7 @@ namespace SPTAG
                 SPTAG::Helper::Convert::ConvertStringTo(index->GetParameter("NumberOfInitialDynamicPivots").c_str(), initSize);
 
               // Build the entire RNG graph, both builds the KNN and refines it to RNG
-                buildGraph<T>(index, m_iGraphSize, m_iNeighborhoodSize, m_iTPTNumber, (int*)m_pNeighborhoodGraph[0], m_iGPURefineSteps, m_iGPURefineDepth, m_iGPUGraphType, m_iGPULeafSize, initSize, m_iGPUBatches, m_iGPUNum);
+                buildGraph<T>(index, m_iGraphSize, m_iNeighborhoodSize, m_iTPTNumber, (int*)m_pNeighborhoodGraph[0], m_iGPURefineSteps, m_iGPURefineDepth, m_iGPUGraphType, m_iGPULeafSize, initSize, m_iGPUBatches);
 
                 if (idmap != nullptr) {
                     std::unordered_map<SizeType, SizeType>::const_iterator iter;
@@ -524,7 +523,7 @@ namespace SPTAG
         public:
             int m_iTPTNumber, m_iTPTLeafSize, m_iSamples, m_numTopDimensionTPTSplit;
             DimensionType m_iNeighborhoodSize;
-            int m_iNeighborhoodScale, m_iCEFScale, m_iRefineIter, m_iCEF, m_iAddCEF, m_iMaxCheckForRefineGraph, m_iGPUGraphType, m_iGPURefineSteps, m_iGPURefineDepth, m_iGPULeafSize, m_iGPUBatches, m_iGPUNum;
+            int m_iNeighborhoodScale, m_iCEFScale, m_iRefineIter, m_iCEF, m_iAddCEF, m_iMaxCheckForRefineGraph, m_iGPUGraphType, m_iGPURefineSteps, m_iGPURefineDepth, m_iGPULeafSize, m_iGPUBatches;
         };
     }
 }

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -47,7 +47,7 @@ namespace SPTAG
                                  m_iGPURefineSteps(0),
                                  m_iGPURefineDepth(2),
                                  m_iGPULeafSize(500),
-                                 m_iGPUBatches(1),
+                                 m_iGPUBatches(1)
             {}
 
             ~NeighborhoodGraph() {}

--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -798,7 +798,7 @@ void buildGraphGPU_Batch(SPTAG::VectorIndex* index, int dataSize, int KVAL, int 
   size_t totalGPUMem = ((size_t)prop.totalGlobalMem) / 1000000;
 
 // If debug/verbose mode, output GPU memory details
-  LOG(SPTAG::Helper::LogLevel::LL_Info, "GPU: %s Total available GPU memory:%zu\n",  prop.name, totalGPUMem);
+  LOG(SPTAG::Helper::LogLevel::LL_Info, "GPU number:%d, model: %s Total available GPU memory:%zu\n",  gpuNum, prop.name, totalGPUMem);
 
   // Print out memory requirements on the GPU
   LOG(SPTAG::Helper::LogLevel::LL_Info, "GPU memory used - input points: %zu MB - tree: %d MB - neighbor lists: %zu MB - Total: %zu MB\n",
@@ -920,12 +920,13 @@ void buildGraphGPU_Batch(SPTAG::VectorIndex* index, int dataSize, int KVAL, int 
  * Function called by SPTAG to create an initial graph on the GPU.  
  ***************************************************************************************/
 template<typename T>
-void buildGraph(SPTAG::VectorIndex* index, int m_iGraphSize, int m_iNeighborhoodSize, int trees, int* results, int refines, int refineDepth, int graph, int leafSize, int initSize, int numBatches, int gpuNum) {
+void buildGraph(SPTAG::VectorIndex* index, int m_iGraphSize, int m_iNeighborhoodSize, int trees, int* results, int refines, int refineDepth, int graph, int leafSize, int initSize, int numBatches) {
 
   int m_iFeatureDim = index->GetFeatureDim();
   int m_disttype = (int)index->GetDistCalcMethod();
 
-  cudaSetDevice(gpuNum);
+  int gpuNum;
+  cudaGetDevice(&gpuNum);
 
   // Make sure that neighborhood size is a power of 2
   if(m_iNeighborhoodSize == 0 || (m_iNeighborhoodSize & (m_iNeighborhoodSize-1)) != 0) {

--- a/AnnService/inc/Core/KDT/ParameterDefinitionList.h
+++ b/AnnService/inc/Core/KDT/ParameterDefinitionList.h
@@ -30,7 +30,6 @@ DefineKDTParameter(m_pGraph.m_iGPURefineSteps, int, 0, "GPURefineSteps") // Step
 DefineKDTParameter(m_pGraph.m_iGPURefineDepth, int, 30, "GPURefineDepth") // Depth of graph search for refinement
 DefineKDTParameter(m_pGraph.m_iGPULeafSize, int, 500, "GPULeafSize")
 DefineKDTParameter(m_pGraph.m_iGPUBatches, int, 1, "GPUBatches")
-DefineKDTParameter(m_pGraph.m_iGPUNum, int, 0, "GPUNum")
 
 DefineKDTParameter(m_iNumberOfThreads, int, 1L, "NumberOfThreads")
 DefineKDTParameter(m_iDistCalcMethod, SPTAG::DistCalcMethod, SPTAG::DistCalcMethod::Cosine, "DistCalcMethod")


### PR DESCRIPTION
Fixed bug that causes default to select GPU number 0, regardless of is available on the system.  Now just selects the default GPU that is activated when execution starts and checks memory requirements, etc. for that GPU.