### PR TITLE
Fix for bug causing rare crash of GPU build on Windows

### DIFF
--- a/AnnService/inc/Core/Common/cuda/Distance.hxx
+++ b/AnnService/inc/Core/Common/cuda/Distance.hxx
@@ -31,7 +31,11 @@
 #include<float.h>
 #include<unordered_set>
 
+#include "inc/Core/VectorIndex.h"
+
 using namespace std;
+
+using namespace SPTAG;
 
 // Templated infinity value
 template<typename T> __host__ __device__ T INFTY() {}
@@ -402,6 +406,30 @@ __host__ Point<T,SUMTYPE,Dim>* extractTailPoints(T* data, int totalRows, std::un
             pointArray[tailIdx].id = i;
             tailIdx++;
         }
+    }
+    return pointArray;
+}
+
+template<typename T, typename SUMTYPE, int Dim>
+__host__ Point<T,SUMTYPE,Dim>* extractFullVectorPoints(T* data, size_t totalRows, int exact_dim) {
+    Point<T,SUMTYPE,Dim>* pointArray = (Point<T,SUMTYPE,Dim>*)malloc(totalRows*sizeof(Point<T,SUMTYPE,Dim>));
+
+    for(size_t i=0; i<totalRows; ++i) {
+        pointArray[i].loadChunk(&data[i*exact_dim], exact_dim);
+        pointArray[i].id = i;
+    }
+    return pointArray;
+}
+
+template<typename T, typename SUMTYPE, int Dim>
+__host__ Point<T,SUMTYPE,Dim>* extractHeadPointsFromIndex(T* data, SPTAG::VectorIndex* headIndex, int exact_dim) {
+
+    size_t headRows = headIndex->GetNumSamples();
+    Point<T,SUMTYPE,Dim>* pointArray = (Point<T,SUMTYPE,Dim>*)malloc(headRows*sizeof(Point<T,SUMTYPE,Dim>));
+
+    for(size_t i=0; i<headRows; ++i) {
+        pointArray[i].loadChunk((T*)headIndex->GetSample(i), exact_dim);
+        pointArray[i].id = i;
     }
     return pointArray;
 }

--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -869,7 +869,9 @@ void buildGraphGPU_Batch(SPTAG::VectorIndex* index, size_t dataSize, size_t KVAL
     LOG(SPTAG::Helper::LogLevel::LL_Info, "Starting batch %d, computing neighbor list for vertices %d through %d\n", batch, min_id, max_id-1);
 
     // Initialize results to all -1 (special value that is set to distance INFTY)
-    CUDA_CHECK(cudaMemset(d_results, -1, (size_t)batchSize*KVAL*sizeof(int)));
+    for(int i=0; i<batchSize*KVAL; ++i) {
+      d_results[i] = -1;
+    }
 
     for(int tree_id=0; tree_id < trees; ++tree_id) { // number of TPTs used to create approx. KNN graph
       CUDA_CHECK(cudaDeviceSynchronize());

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -172,7 +172,8 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
 auto t1 = std::chrono::high_resolution_clock::now();
             tptree->reset();
             create_tptree<T, KEY_T, SUMTYPE, MAX_DIM>(tptree, d_headPoints, headVectorIDS.size(), levels, 0, headVectorIDS.size());
-
+            cudaDeviceSynchronize();
+             
 auto t2 = std::chrono::high_resolution_clock::now();
 
             findTailRNG<T,KEY_T,SUMTYPE,MAX_DIM,NUM_THREADS><<<NUM_BLOCKS, NUM_THREADS, sizeof(DistPair<SUMTYPE>)*RNG_SIZE*NUM_THREADS>>>(d_headPoints, d_tailPoints, tptree, RNG_SIZE, d_results, metric, (size_t)curr_batch_size, (size_t)headVectorIDS.size());

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -108,54 +108,74 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
 
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, gpuNum);
+
+    size_t headRows, tailRows;
+    if(headVectorIDS.size() == 0) { // If list of headVectors is not given, have to extract them from headIndex
+      headRows = headIndex->GetNumSamples();
+      tailRows = N;
+    }
+    else {
+      headRows = headVectorIDS.size();
+      tailRows = N - headRows;
+    }
     
-    size_t headVecSize = headVectorIDS.size()*sizeof(Point<T,SUMTYPE,MAX_DIM>);
-    size_t treeSize = 20*headVectorIDS.size();
+    size_t headVecSize = headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>);
+    size_t treeSize = 20*headRows;
     size_t tailMemAvail = ((size_t)prop.totalGlobalMem) - (headVecSize+treeSize);
     int maxEltsPerBatch = tailMemAvail / (sizeof(Point<T,SUMTYPE,MAX_DIM>) + RNG_SIZE*sizeof(DistPair<SUMTYPE>));
-    int BATCH_SIZE = min(maxEltsPerBatch, (int)(N-headVectorIDS.size()));
+    int BATCH_SIZE = min(maxEltsPerBatch, (int)(tailRows));
 
    // If GPU memory is insufficient or so limited that we need so many batches it becomes inefficient, return error
-    if(BATCH_SIZE == 0 || ((int)(N-headVectorIDS.size())) / BATCH_SIZE > 10000) {
+    if(BATCH_SIZE == 0 || ((int)tailRows) / BATCH_SIZE > 10000) {
       LOG(SPTAG::Helper::LogLevel::LL_Error, "Insufficient GPU memory to build SSD index.  Total GPU memory:%lu MB, Head index requires:%lu MB, leaving a maximum batch size of %d elements, which is too small to run efficiently.\n", ((size_t)prop.totalGlobalMem)/1000000, (headVecSize+treeSize)/1000000, maxEltsPerBatch);
       exit(1);
     }
 
-    LOG(SPTAG::Helper::LogLevel::LL_Info, "Memory for head vectors:%lu MiB, Memory for TP trees:%lu MiB, Memory left for tail vectors:%lu MiB, total tail vectors:%lu, batch size:%d, total batches:%d\n", headVecSize/1000000, treeSize/1000000, tailMemAvail/1000000, (N-headVectorIDS.size()), BATCH_SIZE, (((BATCH_SIZE-1)+N-headVectorIDS.size()) / BATCH_SIZE));
+    LOG(SPTAG::Helper::LogLevel::LL_Info, "Memory for head vectors:%lu MiB, Memory for TP trees:%lu MiB, Memory left for tail vectors:%lu MiB, total tail vectors:%lu, batch size:%d, total batches:%d\n", headVecSize/1000000, treeSize/1000000, tailMemAvail/1000000, tailRows, BATCH_SIZE, (((BATCH_SIZE-1)+tailRows) / BATCH_SIZE));
 
     const int NUM_THREADS = 64;
     int NUM_BLOCKS = min(BATCH_SIZE/NUM_THREADS, 10240);
 
-    Point<T,SUMTYPE,MAX_DIM>* headPoints = extractHeadPoints<T,SUMTYPE,MAX_DIM>(vectors, N, headVectorIDS, dim);
-    Point<T,SUMTYPE,MAX_DIM>* tailPoints = extractTailPoints<T,SUMTYPE,MAX_DIM>(vectors, N, headVectorIDS, dim);
+    Point<T,SUMTYPE,MAX_DIM>* headPoints;
+    Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
+
+    // If headVectors not given, extract from headIndex and use all vectors as tails
+    if(headVectorIDS.size() == 0) {
+      headPoints = extractHeadPointsFromIndex<T,SUMTYPE,MAX_DIM>(vectors, headIndex, dim);
+      tailPoints = extractFullVectorPoints<T,SUMTYPE,MAX_DIM>(vectors, N, dim);
+    }
+    else {
+      headPoints = extractHeadPoints<T,SUMTYPE,MAX_DIM>(vectors, N, headVectorIDS, dim);
+      tailPoints = extractTailPoints<T,SUMTYPE,MAX_DIM>(vectors, N, headVectorIDS, dim);
+    }
 
     Point<T,SUMTYPE,MAX_DIM>* d_tailPoints;
     cudaMalloc(&d_tailPoints, BATCH_SIZE*sizeof(Point<T,SUMTYPE,MAX_DIM>));
 
     Point<T,SUMTYPE,MAX_DIM>* d_headPoints;
-    cudaMalloc(&d_headPoints, headVectorIDS.size()*sizeof(Point<T,SUMTYPE,MAX_DIM>));
-    cudaMemcpy(d_headPoints, headPoints, headVectorIDS.size()*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice);
+    cudaMalloc(&d_headPoints, headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>));
+    cudaMemcpy(d_headPoints, headPoints, headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice);
 
     DistPair<SUMTYPE>* d_results;
     cudaMalloc(&d_results, BATCH_SIZE*RNG_SIZE*sizeof(DistPair<SUMTYPE>));
 
  // Prepare memory for TPTs
-    int levels = (int)std::log2(headVectorIDS.size()/LEAF_SIZE);
+    int levels = (int)std::log2(headRows/LEAF_SIZE);
     TPtree<T,KEY_T,SUMTYPE,MAX_DIM>* tptree;
     CUDA_CHECK(cudaMallocManaged(&tptree, sizeof(TPtree<T,KEY_T,SUMTYPE, MAX_DIM>)));
-    tptree->initialize(headVectorIDS.size(), levels);
+    tptree->initialize(headRows, levels);
 
     size_t curr_batch_size = BATCH_SIZE;
 
 // Get neighbor result set for each batch of tail vectors
-    for(size_t offset=0; offset<(N-headVectorIDS.size()); offset+=BATCH_SIZE) {
+    for(size_t offset=0; offset < tailRows; offset+=BATCH_SIZE) {
         curr_batch_size = BATCH_SIZE;
 
         // Check if final batch is smaller than previous
-        if(offset+BATCH_SIZE > (N-headVectorIDS.size())) {
-            curr_batch_size = (N-headVectorIDS.size())-offset;
+        if(offset+BATCH_SIZE > tailRows) {
+            curr_batch_size = tailRows-offset;
         }
-        LOG(SPTAG::Helper::LogLevel::LL_Info, "Starting batch with offset:%lu, size:%lu, N:%lld\n", offset, curr_batch_size, N);
+        LOG(SPTAG::Helper::LogLevel::LL_Info, "Starting batch with offset:%lu, size:%lu, TailRows:%lld\n", offset, curr_batch_size, tailRows);
 
         auto batch_t1 = std::chrono::high_resolution_clock::now();
     
@@ -171,12 +191,12 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
         for(int tree_id=0; tree_id < NUM_TREES; ++tree_id) {
 auto t1 = std::chrono::high_resolution_clock::now();
             tptree->reset();
-            create_tptree<T, KEY_T, SUMTYPE, MAX_DIM>(tptree, d_headPoints, headVectorIDS.size(), levels, 0, headVectorIDS.size());
+            create_tptree<T, KEY_T, SUMTYPE, MAX_DIM>(tptree, d_headPoints, headRows, levels, 0, headRows);
             cudaDeviceSynchronize();
              
 auto t2 = std::chrono::high_resolution_clock::now();
 
-            findTailRNG<T,KEY_T,SUMTYPE,MAX_DIM,NUM_THREADS><<<NUM_BLOCKS, NUM_THREADS, sizeof(DistPair<SUMTYPE>)*RNG_SIZE*NUM_THREADS>>>(d_headPoints, d_tailPoints, tptree, RNG_SIZE, d_results, metric, (size_t)curr_batch_size, (size_t)headVectorIDS.size());
+            findTailRNG<T,KEY_T,SUMTYPE,MAX_DIM,NUM_THREADS><<<NUM_BLOCKS, NUM_THREADS, sizeof(DistPair<SUMTYPE>)*RNG_SIZE*NUM_THREADS>>>(d_headPoints, d_tailPoints, tptree, RNG_SIZE, d_results, metric, (size_t)curr_batch_size, headRows);
             cudaDeviceSynchronize();
 
 auto t3 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Fixes bug that may cause a crash of GPU build on windows for certain datasets.  Bug is due to difference in implementation of CUDA Unified memory on Windows versus Linux.  