### PR TITLE
Fix perf issues with duplicate vectors for GPU index build

### DIFF
--- a/AnnService/inc/Core/BKT/ParameterDefinitionList.h
+++ b/AnnService/inc/Core/BKT/ParameterDefinitionList.h
@@ -33,6 +33,7 @@ DefineBKTParameter(m_pGraph.m_iGPURefineSteps, int, 0, "GPURefineSteps") // Step
 DefineBKTParameter(m_pGraph.m_iGPURefineDepth, int, 30, "GPURefineDepth") // Depth of graph search for refinement
 DefineBKTParameter(m_pGraph.m_iGPULeafSize, int, 500, "GPULeafSize")
 DefineBKTParameter(m_pGraph.m_iheadNumGPUs, int, 1, "HeadNumGPUs")
+DefineBKTParameter(m_pGraph.m_iTPTBalanceFactor, int, 2, "TPTBalanceFactor")
 
 DefineBKTParameter(m_iNumberOfThreads, int, 1L, "NumberOfThreads")
 DefineBKTParameter(m_iDistCalcMethod, SPTAG::DistCalcMethod, SPTAG::DistCalcMethod::Cosine, "DistCalcMethod")

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -381,6 +381,9 @@ namespace SPTAG
                     auto t2 = std::chrono::high_resolution_clock::now();
                     LOG(Helper::LogLevel::LL_Info, "Refine RNG time (s): %lld Graph Acc: %f\n", std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count(), GraphAccuracyEstimation(index, 100, idmap));
                 }
+                else {
+                    LOG(Helper::LogLevel::LL_Info, "Graph Acc: %f\n", GraphAccuracyEstimation(index, 100, idmap));
+                }
             }
 
             template <typename T>

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -48,7 +48,8 @@ namespace SPTAG
                                  m_iGPURefineSteps(0),
                                  m_iGPURefineDepth(2),
                                  m_iGPULeafSize(500),
-                                 m_iheadNumGPUs(1)
+                                 m_iheadNumGPUs(1),
+                                 m_iTPTBalanceFactor(2)
             {}
 
             ~NeighborhoodGraph() {}
@@ -106,7 +107,7 @@ namespace SPTAG
                 SPTAG::Helper::Convert::ConvertStringTo(index->GetParameter("NumberOfInitialDynamicPivots").c_str(), initSize);
 
               // Build the entire RNG graph, both builds the KNN and refines it to RNG
-                buildGraph<T>(index, m_iGraphSize, m_iNeighborhoodSize, m_iTPTNumber, (int*)m_pNeighborhoodGraph[0], m_iGPURefineSteps, m_iGPURefineDepth, m_iGPUGraphType, m_iGPULeafSize, initSize, m_iheadNumGPUs);
+                buildGraph<T>(index, m_iGraphSize, m_iNeighborhoodSize, m_iTPTNumber, (int*)m_pNeighborhoodGraph[0], m_iGPURefineSteps, m_iGPURefineDepth, m_iGPUGraphType, m_iGPULeafSize, initSize, m_iheadNumGPUs, m_iTPTBalanceFactor);
 
                 if (idmap != nullptr) {
                     std::unordered_map<SizeType, SizeType>::const_iterator iter;
@@ -380,9 +381,6 @@ namespace SPTAG
                     auto t2 = std::chrono::high_resolution_clock::now();
                     LOG(Helper::LogLevel::LL_Info, "Refine RNG time (s): %lld Graph Acc: %f\n", std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count(), GraphAccuracyEstimation(index, 100, idmap));
                 }
-                else {
-                    LOG(Helper::LogLevel::LL_Info, "Graph Acc: %f\n", GraphAccuracyEstimation(index, 100, idmap));
-                }
             }
 
             template <typename T>
@@ -537,7 +535,7 @@ namespace SPTAG
             int m_iTPTNumber, m_iTPTLeafSize, m_iSamples, m_numTopDimensionTPTSplit;
             DimensionType m_iNeighborhoodSize;
             float m_fNeighborhoodScale, m_fCEFScale, m_fRNGFactor;
-            int m_iRefineIter, m_iCEF, m_iAddCEF, m_iMaxCheckForRefineGraph, m_iGPUGraphType, m_iGPURefineSteps, m_iGPURefineDepth, m_iGPULeafSize, m_iheadNumGPUs;
+            int m_iRefineIter, m_iCEF, m_iAddCEF, m_iMaxCheckForRefineGraph, m_iGPUGraphType, m_iGPURefineSteps, m_iGPURefineDepth, m_iGPULeafSize, m_iheadNumGPUs, m_iTPTBalanceFactor;
         };
     }
 }

--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -770,7 +770,7 @@ void buildGraphGPU(SPTAG::VectorIndex* index, int dataSize, int KVAL, int trees,
  ***************************************************************************************/
 
 template<typename DTYPE, typename SUMTYPE, int MAX_DIM>
-void buildGraphGPU_Batch(SPTAG::VectorIndex* index, size_t dataSize, size_t KVAL, int trees, int* results, int graphtype, int leafSize, int NUM_GPUS) {
+void buildGraphGPU_Batch(SPTAG::VectorIndex* index, size_t dataSize, size_t KVAL, int trees, int* results, int graphtype, int leafSize, int NUM_GPUS, int balanceFactor) {
 
   int numDevicesOnHost;
   CUDA_CHECK(cudaGetDeviceCount(&numDevicesOnHost));
@@ -915,7 +915,7 @@ auto before_tpt = std::chrono::high_resolution_clock::now();
         CUDA_CHECK(cudaSetDevice(gpuNum));
         tptrees[gpuNum]->reset();
       }
-      create_tptree_multigpu<DTYPE, KEYTYPE, SUMTYPE, MAX_DIM>(tptrees, d_points, dataSize, levels, NUM_GPUS, streams.data());
+      create_tptree_multigpu<DTYPE, KEYTYPE, SUMTYPE, MAX_DIM>(tptrees, d_points, dataSize, levels, NUM_GPUS, streams.data(), balanceFactor);
       CUDA_CHECK(cudaDeviceSynchronize());
 
             // Copy TPTs to each GPU
@@ -985,7 +985,7 @@ auto end_t = std::chrono::high_resolution_clock::now();
  * Function called by SPTAG to create an initial graph on the GPU.  
  ***************************************************************************************/
 template<typename T>
-void buildGraph(SPTAG::VectorIndex* index, int m_iGraphSize, int m_iNeighborhoodSize, int trees, int* results, int refines, int refineDepth, int graph, int leafSize, int initSize, int NUM_GPUS) {
+void buildGraph(SPTAG::VectorIndex* index, int m_iGraphSize, int m_iNeighborhoodSize, int trees, int* results, int refines, int refineDepth, int graph, int leafSize, int initSize, int NUM_GPUS, int balanceFactor) {
 
   int m_iFeatureDim = index->GetFeatureDim();
   int m_disttype = (int)index->GetDistCalcMethod();
@@ -1006,18 +1006,18 @@ void buildGraph(SPTAG::VectorIndex* index, int m_iGraphSize, int m_iNeighborhood
   }
   if(typeid(T) == typeid(float)) {
     if(m_iFeatureDim <= 64) {
-      buildGraphGPU_Batch<T, float, 64>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS);
+      buildGraphGPU_Batch<T, float, 64>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS, balanceFactor);
     }
     else {
-      buildGraphGPU_Batch<T, float, 100>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS);
+      buildGraphGPU_Batch<T, float, 100>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS, balanceFactor);
     }
   }
   else if(typeid(T) == typeid(uint8_t) || typeid(T) == typeid(int8_t)) {
     if(m_iFeatureDim <= 64) {
-      buildGraphGPU_Batch<T, int32_t, 64>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS);
+      buildGraphGPU_Batch<T, int32_t, 64>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS, balanceFactor);
     }
     else {
-      buildGraphGPU_Batch<T, int32_t, 100>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS);
+      buildGraphGPU_Batch<T, int32_t, 100>(index, (size_t)m_iGraphSize, (size_t)m_iNeighborhoodSize, trees, results, graph, leafSize, NUM_GPUS, balanceFactor);
     }
   }
   else {

--- a/AnnService/inc/Core/Common/cuda/TPtree.hxx
+++ b/AnnService/inc/Core/Common/cuda/TPtree.hxx
@@ -429,9 +429,7 @@ __global__ void find_level_sum(Point<T,SUMTYPE,Dim>* points, KEY_T* weights, int
   KEY_T val=0;
   int size = min(N, nodes_on_level*SAMPLES);
   int step = N/size;
-//if(threadIdx.x==0 && blockIdx.x==0) printf("find level sum, size:%d, step:%d\n", size, step);
   for(int i=blockIdx.x*blockDim.x+threadIdx.x; i<size; i+=blockDim.x*gridDim.x) {
-//  for(int i=(blockIdx.x*blockDim.x+threadIdx.x)*step; i<N; i+=blockDim.x*gridDim.x*step) {
     val = weighted_val<T,KEY_T,SUMTYPE,Dim,PART_DIMS>(points[i], &weights[level*Dim], partition_dims);
     atomicAdd(&split_keys[node_ids[i]], val);
     atomicAdd(&node_sizes[node_ids[i]], 1);

--- a/AnnService/inc/Core/Common/cuda/TPtree.hxx
+++ b/AnnService/inc/Core/Common/cuda/TPtree.hxx
@@ -29,6 +29,8 @@
 #include<iostream>
 #include<queue>
 #include <cuda.h>
+#include <limits.h>
+#include <curand_kernel.h>
 #include "params.h"
 #include "Distance.hxx"
 
@@ -56,6 +58,13 @@ __global__ void update_node_assignments(Point<T,SUMTYPE,Dim>* points, KEY_T* wei
  * Determine the sizes (number of points in) each leaf node and sets leafs.size
  ************************************************************************************/
 __global__ void count_leaf_sizes(LeafNode* leafs, int* node_ids, int N, int internal_nodes);
+
+
+__global__ void check_for_imbalance(int* node_ids, int* node_sizes, int nodes_on_level, int ndoe_start, float* frac_to_move, int balanceFactor);
+
+__global__ void initialize_rands(curandState* states, int iter);
+
+__global__ void rebalance_nodes(int* node_ids, int N, float* frac_to_move, curandState* states);
 
 
 /************************************************************************************
@@ -264,29 +273,74 @@ __host__ void create_tptree(TPtree<T,KEY_T,SUMTYPE,Dim>* d_tree, Point<T,SUMTYPE
 }
 
 
+// Construct TPT on each GPU 
 template<typename T, typename KEY_T, typename SUMTYPE, int Dim>
-__host__ void construct_trees_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Point<T,SUMTYPE,Dim>** points, int N, int NUM_GPUS, cudaStream_t* streams) {
+__host__ void construct_trees_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Point<T,SUMTYPE,Dim>** points, int N, int NUM_GPUS, cudaStream_t* streams, int balanceFactor) {
 
     int nodes_on_level=1;
+
+    const int RUN_BLOCKS = min(N/THREADS, BLOCKS);
+
+
+    float** frac_to_move = new float*[NUM_GPUS];
+    curandState** states = new curandState*[NUM_GPUS];
+
+    for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+        CUDA_CHECK(cudaSetDevice(gpuNum));
+        CUDA_CHECK(cudaMalloc(&frac_to_move[gpuNum], d_trees[0]->num_nodes*sizeof(float)));
+        CUDA_CHECK(cudaMalloc(&states[gpuNum], N*sizeof(curandState)));
+        initialize_rands<<<RUN_BLOCKS,THREADS>>>(states[gpuNum], 0);
+
+    }
+
+  
     for(int i=0; i<d_trees[0]->levels; ++i) {
         for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
             cudaSetDevice(gpuNum);
 
-            find_level_sum<T,KEY_T,SUMTYPE,Dim,Dim><<<BLOCKS,THREADS,0,streams[gpuNum]>>>(points[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->partition_dims, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, nodes_on_level, i);
+            find_level_sum<T,KEY_T,SUMTYPE,Dim,Dim><<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(points[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->partition_dims, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, nodes_on_level, i);
 
-            compute_mean<KEY_T><<<BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, d_trees[gpuNum]->num_nodes);
 
-            update_node_assignments<T,KEY_T,SUMTYPE,Dim,Dim><<<BLOCKS,THREADS,0,streams[gpuNum]>>>(points[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->partition_dims, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, i);
         }
 
+        // Check and rebalance all levels beyond the first (first level has only 1 node)
+        if(i > 0) {
+            for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+                cudaSetDevice(gpuNum);
+
+                // Compute imbalance factors for each node on level
+                check_for_imbalance<<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->node_ids, d_trees[gpuNum]->node_sizes, nodes_on_level, nodes_on_level-1, frac_to_move[gpuNum], balanceFactor);
+
+                // Randomly reassign points to neighboring nodes as needed based on imbalance factor
+                rebalance_nodes<<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->node_ids, N, frac_to_move[gpuNum], states[gpuNum]);
+            }
+        }
+
+        for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+            cudaSetDevice(gpuNum);
+
+            compute_mean<KEY_T><<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, d_trees[gpuNum]->num_nodes);
+
+            update_node_assignments<T,KEY_T,SUMTYPE,Dim,Dim><<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(points[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->partition_dims, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, i);
+        }
         nodes_on_level*=2;
+
     }
+
+    // Free memory used for rebalancing, etc.
+    for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+        cudaSetDevice(gpuNum);
+        cudaFree(frac_to_move[gpuNum]);
+        cudaFree(states[gpuNum]);
+    }
+    delete[] frac_to_move;
+    delete[] states;
 
     LeafNode* h_leafs = new LeafNode[d_trees[0]->num_leaves];
 
     for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
         cudaSetDevice(gpuNum);
-        count_leaf_sizes<<<BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves);
+        count_leaf_sizes<<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves);
 
         CUDA_CHECK(cudaMemcpyAsync(h_leafs, d_trees[gpuNum]->leafs, d_trees[gpuNum]->num_leaves*sizeof(LeafNode), cudaMemcpyDeviceToHost, streams[gpuNum]));
 
@@ -300,20 +354,20 @@ __host__ void construct_trees_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Po
 
         CUDA_CHECK(cudaMemcpyAsync(d_trees[gpuNum]->leafs, h_leafs, d_trees[gpuNum]->num_leaves*sizeof(LeafNode), cudaMemcpyHostToDevice, streams[gpuNum]));
 
-        assign_leaf_points_in_batch<<<BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->leaf_points, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves, 0, N);
+        assign_leaf_points_in_batch<<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->leaf_points, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves, 0, N);
     }
 
     delete[] h_leafs;
 
     for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
         cudaSetDevice(gpuNum);
-        assign_leaf_points_out_batch<<<BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->leaf_points, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves, 0, N);
+        assign_leaf_points_out_batch<<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(d_trees[gpuNum]->leafs, d_trees[gpuNum]->leaf_points, d_trees[gpuNum]->node_ids, N, d_trees[gpuNum]->num_nodes - d_trees[gpuNum]->num_leaves, 0, N);
     }
 }
 
 
 template<typename T, typename KEY_T, typename SUMTYPE, int Dim>
-__host__ void create_tptree_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Point<T,SUMTYPE,Dim>** points, int N, int MAX_LEVELS, int NUM_GPUS, cudaStream_t* streams) {
+__host__ void create_tptree_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Point<T,SUMTYPE,Dim>** points, int N, int MAX_LEVELS, int NUM_GPUS, cudaStream_t* streams, int balanceFactor) {
 
   KEY_T* h_weights = new KEY_T[d_trees[0]->levels*Dim];
   for(int i=0; i<d_trees[0]->levels*Dim; ++i) {
@@ -328,7 +382,7 @@ __host__ void create_tptree_multigpu(TPtree<T,KEY_T,SUMTYPE,Dim>** d_trees, Poin
   }
 
   // Build TPT on each GPU  
-  construct_trees_multigpu<T,KEY_T,SUMTYPE,Dim>(d_trees, points, N, NUM_GPUS, streams);
+  construct_trees_multigpu<T,KEY_T,SUMTYPE,Dim>(d_trees, points, N, NUM_GPUS, streams, balanceFactor);
 
   delete h_weights;
 }
@@ -374,7 +428,10 @@ template<typename T, typename KEY_T, typename SUMTYPE, int Dim, int PART_DIMS>
 __global__ void find_level_sum(Point<T,SUMTYPE,Dim>* points, KEY_T* weights, int* partition_dims, int* node_ids, KEY_T* split_keys, int* node_sizes, int N, int nodes_on_level, int level) {
   KEY_T val=0;
   int size = min(N, nodes_on_level*SAMPLES);
+  int step = N/size;
+//if(threadIdx.x==0 && blockIdx.x==0) printf("find level sum, size:%d, step:%d\n", size, step);
   for(int i=blockIdx.x*blockDim.x+threadIdx.x; i<size; i+=blockDim.x*gridDim.x) {
+//  for(int i=(blockIdx.x*blockDim.x+threadIdx.x)*step; i<N; i+=blockDim.x*gridDim.x*step) {
     val = weighted_val<T,KEY_T,SUMTYPE,Dim,PART_DIMS>(points[i], &weights[level*Dim], partition_dims);
     atomicAdd(&split_keys[node_ids[i]], val);
     atomicAdd(&node_sizes[node_ids[i]], 1);

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -223,8 +223,6 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
     }
     int TPTlevels = (int)std::log2(headRows/LEAF_SIZE);
 
-    printf("tailRows:%ld\n", tailRows);
-
     Point<T,SUMTYPE,MAX_DIM>* headPoints;
     Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
     headPoints = new Point<T,SUMTYPE,MAX_DIM>[headRows];
@@ -299,8 +297,6 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
 
         BATCH_SIZE[gpuNum] = min(maxEltsPerBatch, (int)(tailsPerGPU[gpuNum]));
 
-printf("headPointSize:%ld, treeSize:%ld, tailMemAvail:%ld, maxEltsPerBatch:%d, batch_size:%ld, total batches:%ld\n", headVecSize, treeSize, tailMemAvail, maxEltsPerBatch, BATCH_SIZE[gpuNum], ((size_t)tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum]);
-  
        // If GPU memory is insufficient or so limited that we need so many batches it becomes inefficient, return error
         if(BATCH_SIZE[gpuNum] == 0 || ((int)tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum] > 10000) {
             LOG(SPTAG::Helper::LogLevel::LL_Error, "Insufficient GPU memory to build SSD index on GPU %d.  Available GPU memory:%lu MB, Head index requires:%lu MB, leaving a maximum batch size of %d elements, which is too small to run efficiently.\n", gpuNum, (freeMem)/1000000, (headVecSize+treeSize)/1000000, maxEltsPerBatch);

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -223,6 +223,8 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
     }
     int TPTlevels = (int)std::log2(headRows/LEAF_SIZE);
 
+    printf("tailRows:%ld\n", tailRows);
+
     Point<T,SUMTYPE,MAX_DIM>* headPoints;
     Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
     headPoints = new Point<T,SUMTYPE,MAX_DIM>[headRows];
@@ -245,6 +247,7 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
         if(tailRows % NUM_GPUS > gpuNum) tailsPerGPU[gpuNum]++;
     }
     GPUOffset[0] = 0;
+    LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU 0: tails:%lu, offset:%lu\n", tailsPerGPU[0], GPUOffset[0]);
     LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU 0: tails:%lu, offset:%lu\n", tailsPerGPU[0], GPUOffset[0]);
     for(int gpuNum=1; gpuNum < NUM_GPUS; ++gpuNum) {
         GPUOffset[gpuNum] = GPUOffset[gpuNum-1] + tailsPerGPU[gpuNum-1];
@@ -295,6 +298,8 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
         int maxEltsPerBatch = tailMemAvail / (sizeof(Point<T,SUMTYPE,MAX_DIM>) + RNG_SIZE*sizeof(DistPair<SUMTYPE>) + 2*sizeof(int));
 
         BATCH_SIZE[gpuNum] = min(maxEltsPerBatch, (int)(tailsPerGPU[gpuNum]));
+
+printf("headPointSize:%ld, treeSize:%ld, tailMemAvail:%ld, maxEltsPerBatch:%d, batch_size:%ld, total batches:%ld\n", headVecSize, treeSize, tailMemAvail, maxEltsPerBatch, BATCH_SIZE[gpuNum], ((size_t)tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum]);
   
        // If GPU memory is insufficient or so limited that we need so many batches it becomes inefficient, return error
         if(BATCH_SIZE[gpuNum] == 0 || ((int)tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum] > 10000) {
@@ -376,7 +381,7 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
 
 auto t1 = std::chrono::high_resolution_clock::now();
             // Create TPT on each GPU
-            create_tptree_multigpu<T, KEY_T, SUMTYPE, MAX_DIM>(tptree, d_headPoints, headRows, TPTlevels, NUM_GPUS, streams.data());
+            create_tptree_multigpu<T, KEY_T, SUMTYPE, MAX_DIM>(tptree, d_headPoints, headRows, TPTlevels, NUM_GPUS, streams.data(), 2);
             CUDA_CHECK(cudaDeviceSynchronize());
             LOG(SPTAG::Helper::LogLevel::LL_Debug, "TPT %d created on all GPUs\n", tree_id);
 

--- a/AnnService/inc/Core/KDT/ParameterDefinitionList.h
+++ b/AnnService/inc/Core/KDT/ParameterDefinitionList.h
@@ -12,7 +12,6 @@ DefineKDTParameter(m_sDeleteDataPointsFilename, std::string, std::string("delete
 DefineKDTParameter(m_pTrees.m_iTreeNumber, int, 1L, "KDTNumber")
 DefineKDTParameter(m_pTrees.m_numTopDimensionKDTSplit, int, 5L, "NumTopDimensionKDTSplit")
 DefineKDTParameter(m_pTrees.m_iSamples, int, 100L, "Samples")
-DefineKDTParameter(m_pTrees.m_bOldVersion, bool, false, "IsOldVersion")
 
 DefineKDTParameter(m_pGraph.m_iTPTNumber, int, 32L, "TPTNumber")
 DefineKDTParameter(m_pGraph.m_iTPTLeafSize, int, 2000L, "TPTLeafSize")
@@ -32,6 +31,7 @@ DefineKDTParameter(m_pGraph.m_iGPURefineSteps, int, 0, "GPURefineSteps") // Step
 DefineKDTParameter(m_pGraph.m_iGPURefineDepth, int, 30, "GPURefineDepth") // Depth of graph search for refinement
 DefineKDTParameter(m_pGraph.m_iGPULeafSize, int, 500, "GPULeafSize")
 DefineKDTParameter(m_pGraph.m_iheadNumGPUs, int, 1, "HeadNumGPUs")
+DefineKDTParameter(m_pGraph.m_iTPTBalanceFactor, int, 2, "TPTBalanceFactor")
 
 DefineKDTParameter(m_iNumberOfThreads, int, 1L, "NumberOfThreads")
 DefineKDTParameter(m_iDistCalcMethod, SPTAG::DistCalcMethod, SPTAG::DistCalcMethod::Cosine, "DistCalcMethod")

--- a/AnnService/inc/Core/KDT/ParameterDefinitionList.h
+++ b/AnnService/inc/Core/KDT/ParameterDefinitionList.h
@@ -12,6 +12,7 @@ DefineKDTParameter(m_sDeleteDataPointsFilename, std::string, std::string("delete
 DefineKDTParameter(m_pTrees.m_iTreeNumber, int, 1L, "KDTNumber")
 DefineKDTParameter(m_pTrees.m_numTopDimensionKDTSplit, int, 5L, "NumTopDimensionKDTSplit")
 DefineKDTParameter(m_pTrees.m_iSamples, int, 100L, "Samples")
+DefineKDTParameter(m_pTrees.m_bOldVersion, bool, false, "IsOldVersion")
 
 DefineKDTParameter(m_pGraph.m_iTPTNumber, int, 32L, "TPTNumber")
 DefineKDTParameter(m_pGraph.m_iTPTLeafSize, int, 2000L, "TPTLeafSize")

--- a/AnnService/src/Core/Common/Kernel.cu
+++ b/AnnService/src/Core/Common/Kernel.cu
@@ -27,6 +27,7 @@
 #include <device_launch_parameters.h>
 #include <typeinfo>
 #include <cuda_fp16.h>
+#include <curand_kernel.h>
 
 #include "inc/Core/Common/cuda/params.h"
 #include "inc/Core/Common/cuda/TPtree.hxx"
@@ -81,5 +82,39 @@ __global__ void assign_leaf_points_out_batch(LeafNode* leafs, int* leaf_points, 
         idx = atomicAdd(&leafs[leaf_id].size, 1);
         leaf_points[idx + leafs[leaf_id].offset] = i;
     }
+}
+
+
+//#define BAL 2 // Balance factor - will only rebalance nodes that are at least 2x larger than their sibling
+
+// Computes the fraction of points that need to be moved from each unbalanced node on the level
+__global__ void check_for_imbalance(int* node_ids, int* node_sizes, int nodes_on_level, int node_start, float* frac_to_move, int bal_factor) {
+  int neighborId;
+  for(int i=node_start + blockIdx.x*blockDim.x + threadIdx.x; i<node_start+nodes_on_level; i+=blockDim.x*gridDim.x) {
+    frac_to_move[i] = 0.0;
+    neighborId = (i-1) + 2*(i&1); // neighbor is either left or right of current
+    if(node_sizes[i] > bal_factor*node_sizes[neighborId]) {
+      frac_to_move[i] = ((float)node_sizes[i] - (((float)(node_sizes[i]+node_sizes[neighborId]))/2.0)) / (float)node_sizes[i];
+    }
+  }
+}
+
+// Initialize random number generator for each thread
+__global__ void initialize_rands(curandState* states, int iter) {
+  int id = threadIdx.x + blockIdx.x*blockDim.x;
+  curand_init(1234, id, iter, &states[id]);
+}
+
+// Randomly move points to sibling nodes based on the fraction that need to be moved out of unbalanced nodes
+__global__ void rebalance_nodes(int* node_ids, int N, float* frac_to_move, curandState* states) {
+  int neighborId;
+  int threadId = blockIdx.x*blockDim.x+threadIdx.x;
+
+  for(int i=threadId; i<N; i+=blockDim.x*gridDim.x) {
+    if((frac_to_move[node_ids[i]] > 0.0) && (curand_uniform(&states[threadId]) < frac_to_move[node_ids[i]])) {
+      neighborId = (node_ids[i]-1) + 2*(node_ids[i]&1); // Compute idx of left or right neighbor
+      node_ids[i] = neighborId;
+    }
+  }
 }
 


### PR DESCRIPTION
Added a check and fix unbalanced TPT nodes for GPU index build.  Overall, slows down the GPU TPT construction, but will greatly speed up overall runtime for highly skewed datasets or those with many duplicate vectors.