### PR TITLE
Fix bug with data conversion for GPU

### DIFF
--- a/AnnService/inc/Core/Common/cuda/Distance.hxx
+++ b/AnnService/inc/Core/Common/cuda/Distance.hxx
@@ -382,6 +382,19 @@ __host__ Point<T, SUMTYPE, Dim>* convertMatrix(T* data, int rows, int exact_dim)
 } 
 
 template<typename T, typename SUMTYPE, int Dim>
+__host__ Point<T, SUMTYPE, Dim>* convertMatrix(SPTAG::VectorIndex* index, size_t rows, int exact_dim) {
+  Point<T,SUMTYPE,Dim>* pointArray = (Point<T,SUMTYPE,Dim>*)malloc(rows*sizeof(Point<T,SUMTYPE,Dim>));
+
+  T* data;
+
+  for(int i=0; i<rows; i++) {
+    data = (T*)index->GetSample(i);
+    pointArray[i].loadChunk(data, exact_dim);
+  }
+  return pointArray;
+}
+
+template<typename T, typename SUMTYPE, int Dim>
 __host__ void extractHeadPoints(T* data, Point<T,SUMTYPE,Dim>* headPoints, size_t totalRows, std::unordered_set<int> headVectorIDS, int exact_dim) {
     int headIdx=0;
     for(size_t i=0; i<totalRows; i++) {

--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -800,7 +800,8 @@ void buildGraphGPU_Batch(SPTAG::VectorIndex* index, size_t dataSize, size_t KVAL
 
   int KNN_blocks; // number of threadblocks used
 
-  Point<DTYPE,SUMTYPE,MAX_DIM>* points = convertMatrix<DTYPE,SUMTYPE,MAX_DIM>(data, dataSize, dim);
+//  Point<DTYPE,SUMTYPE,MAX_DIM>* points = convertMatrix<DTYPE,SUMTYPE,MAX_DIM>(data, dataSize, dim);
+  Point<DTYPE,SUMTYPE,MAX_DIM>* points = convertMatrix<DTYPE,SUMTYPE,MAX_DIM>(index, dataSize, dim);
 
   for(size_t i=0;  i<dataSize; i++) {
     points[i].id = i;

--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -800,7 +800,6 @@ void buildGraphGPU_Batch(SPTAG::VectorIndex* index, size_t dataSize, size_t KVAL
 
   int KNN_blocks; // number of threadblocks used
 
-//  Point<DTYPE,SUMTYPE,MAX_DIM>* points = convertMatrix<DTYPE,SUMTYPE,MAX_DIM>(data, dataSize, dim);
   Point<DTYPE,SUMTYPE,MAX_DIM>* points = convertMatrix<DTYPE,SUMTYPE,MAX_DIM>(index, dataSize, dim);
 
   for(size_t i=0;  i<dataSize; i++) {


### PR DESCRIPTION
Fix for bug that can cause out-of-bounds access when large datasets use small batches.  Data converter takes index and converts to GPU structures now correctly follows pointers when data is non-contiguous.