### PR TITLE
enabled appdirect mode for indexsearcher

### DIFF
--- a/AnnService/inc/Core/BKT/Index.h
+++ b/AnnService/inc/Core/BKT/Index.h
@@ -147,7 +147,8 @@ namespace SPTAG
             ErrorCode SaveIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams);
 
             ErrorCode LoadConfig(Helper::IniReader& p_reader);
-            ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams);
+            // Intel PM change
+            ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams, bool data_in_pm, bool graph_in_pm, std::string p_pm_path);
             ErrorCode LoadIndexDataFromMemory(const std::vector<ByteArray>& p_indexBlobs);
 
             ErrorCode BuildIndex(const void* p_data, SizeType p_vectorNum, DimensionType p_dimension);

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -451,30 +451,30 @@ namespace SPTAG
                 return m_pNeighborhoodGraph.BufferSize();
             }
 
-            ErrorCode LoadGraph(std::shared_ptr<Helper::DiskPriorityIO> input, SizeType blockSize, SizeType capacity)
+            ErrorCode LoadGraph(std::shared_ptr<Helper::DiskPriorityIO> input, SizeType blockSize, SizeType capacity, std::string p_pm_path="")
             {
                 ErrorCode ret = ErrorCode::Success;
-                if ((ret = m_pNeighborhoodGraph.Load(input, blockSize, capacity)) != ErrorCode::Success) return ret;
+                if ((ret = m_pNeighborhoodGraph.Load(input, blockSize, capacity, p_pm_path)) != ErrorCode::Success) return ret;
 
                 m_iGraphSize = m_pNeighborhoodGraph.R();
                 m_iNeighborhoodSize = m_pNeighborhoodGraph.C();
                 return ret;
             }
 
-            ErrorCode LoadGraph(std::string sGraphFilename, SizeType blockSize, SizeType capacity)
+            ErrorCode LoadGraph(std::string sGraphFilename, SizeType blockSize, SizeType capacity, std::string p_pm_path="")
             {
                 ErrorCode ret = ErrorCode::Success;
-                if ((ret = m_pNeighborhoodGraph.Load(sGraphFilename, blockSize, capacity)) != ErrorCode::Success) return ret;
+                if ((ret = m_pNeighborhoodGraph.Load(sGraphFilename, blockSize, capacity, p_pm_path)) != ErrorCode::Success) return ret;
 
                 m_iGraphSize = m_pNeighborhoodGraph.R();
                 m_iNeighborhoodSize = m_pNeighborhoodGraph.C();
                 return ret;
             }
             
-            ErrorCode LoadGraph(char* pGraphMemFile, SizeType blockSize, SizeType capacity)
+            ErrorCode LoadGraph(char* pGraphMemFile, SizeType blockSize, SizeType capacity, std::string p_pm_path="")
             {
                 ErrorCode ret = ErrorCode::Success;
-                if ((ret = m_pNeighborhoodGraph.Load(pGraphMemFile, blockSize, capacity)) != ErrorCode::Success) return ret;
+                if ((ret = m_pNeighborhoodGraph.Load(pGraphMemFile, blockSize, capacity, p_pm_path)) != ErrorCode::Success) return ret;
 
                 m_iGraphSize = m_pNeighborhoodGraph.R();
                 m_iNeighborhoodSize = m_pNeighborhoodGraph.C();

--- a/AnnService/inc/Core/KDT/Index.h
+++ b/AnnService/inc/Core/KDT/Index.h
@@ -145,7 +145,8 @@ namespace SPTAG
             ErrorCode SaveIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams);
 
             ErrorCode LoadConfig(Helper::IniReader& p_reader);
-            ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams);
+            // Intel PM change
+            ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams, bool data_in_pm, bool graph_in_pm, std::string p_pm_path);
             ErrorCode LoadIndexDataFromMemory(const std::vector<ByteArray>& p_indexBlobs);
 
             ErrorCode BuildIndex(const void* p_data, SizeType p_vectorNum, DimensionType p_dimension);

--- a/AnnService/inc/Core/VectorIndex.h
+++ b/AnnService/inc/Core/VectorIndex.h
@@ -98,7 +98,8 @@ public:
 
     static std::shared_ptr<VectorIndex> CreateInstance(IndexAlgoType p_algo, VectorValueType p_valuetype);
 
-    static ErrorCode LoadIndex(const std::string& p_loaderFilePath, std::shared_ptr<VectorIndex>& p_vectorIndex);
+    // Intel PM Change
+    static ErrorCode LoadIndex(const std::string& p_loaderFilePath, std::shared_ptr<VectorIndex>& p_vectorIndex, bool data_in_pm=false, bool graph_in_pm=false, std::string p_pm_path="");
 
     static ErrorCode LoadIndexFromFile(const std::string& p_file, std::shared_ptr<VectorIndex>& p_vectorIndex);
 
@@ -118,8 +119,9 @@ protected:
     virtual ErrorCode SaveIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams) = 0;
 
     virtual ErrorCode LoadConfig(Helper::IniReader& p_reader) = 0;
-
-    virtual ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams) = 0;
+    
+    // Intel PM Change
+    virtual ErrorCode LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams, bool data_in_pm=false, bool graph_in_pm=false, std::string p_pm_path="") = 0;
 
     virtual ErrorCode LoadIndexDataFromMemory(const std::vector<ByteArray>& p_indexBlobs) = 0;
 

--- a/AnnService/src/Core/BKT/BKTIndex.cpp
+++ b/AnnService/src/Core/BKT/BKTIndex.cpp
@@ -44,14 +44,19 @@ namespace SPTAG
         }
 
         template <typename T>
-        ErrorCode Index<T>::LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams)
+        ErrorCode Index<T>::LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams, bool data_in_pm , bool graph_in_pm, std::string p_pm_path )
         {
             if (p_indexStreams.size() < 4) return ErrorCode::LackOfInputs;
+            
+            std::string data_pm_path = "";
+            if (data_in_pm) data_pm_path = p_pm_path;
+            std::string graph_pm_path = "";
+            if (graph_in_pm) graph_pm_path = p_pm_path;
 
             ErrorCode ret = ErrorCode::Success;
-            if (p_indexStreams[0] == nullptr || (ret = m_pSamples.Load(p_indexStreams[0], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
+            if (p_indexStreams[0] == nullptr || (ret = m_pSamples.Load(p_indexStreams[0], m_iDataBlockSize, m_iDataCapacity,data_pm_path)) != ErrorCode::Success) return ret;
             if (p_indexStreams[1] == nullptr || (ret = m_pTrees.LoadTrees(p_indexStreams[1])) != ErrorCode::Success) return ret;
-            if (p_indexStreams[2] == nullptr || (ret = m_pGraph.LoadGraph(p_indexStreams[2], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
+            if (p_indexStreams[2] == nullptr || (ret = m_pGraph.LoadGraph(p_indexStreams[2], m_iDataBlockSize, m_iDataCapacity, graph_pm_path)) != ErrorCode::Success) return ret;
             if (p_indexStreams[3] == nullptr) m_deletedID.Initialize(m_pSamples.R(), m_iDataBlockSize, m_iDataCapacity);
             else if ((ret = m_deletedID.Load(p_indexStreams[3], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
 

--- a/AnnService/src/Core/KDT/KDTIndex.cpp
+++ b/AnnService/src/Core/KDT/KDTIndex.cpp
@@ -44,14 +44,19 @@ namespace SPTAG
         }
 
         template <typename T>
-        ErrorCode Index<T>::LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams)
+        ErrorCode Index<T>::LoadIndexData(const std::vector<std::shared_ptr<Helper::DiskPriorityIO>>& p_indexStreams, bool data_in_pm , bool graph_in_pm , std::string p_pm_path ) 
         {
             if (p_indexStreams.size() < 4) return ErrorCode::LackOfInputs;
 
+            std::string data_pm_path = "";
+            if (data_in_pm) data_pm_path = p_pm_path;
+            std::string graph_pm_path = "";
+            if (graph_in_pm) graph_pm_path = p_pm_path;
+
             ErrorCode ret = ErrorCode::Success;
-            if (p_indexStreams[0] == nullptr || (ret = m_pSamples.Load(p_indexStreams[0], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
+            if (p_indexStreams[0] == nullptr || (ret = m_pSamples.Load(p_indexStreams[0], m_iDataBlockSize, m_iDataCapacity,data_pm_path)) != ErrorCode::Success) return ret;
             if (p_indexStreams[1] == nullptr || (ret = m_pTrees.LoadTrees(p_indexStreams[1])) != ErrorCode::Success) return ret;
-            if (p_indexStreams[2] == nullptr || (ret = m_pGraph.LoadGraph(p_indexStreams[2], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
+            if (p_indexStreams[2] == nullptr || (ret = m_pGraph.LoadGraph(p_indexStreams[2], m_iDataBlockSize, m_iDataCapacity, graph_pm_path)) != ErrorCode::Success) return ret;
             if (p_indexStreams[3] == nullptr) m_deletedID.Initialize(m_pSamples.R(), m_iDataBlockSize, m_iDataCapacity);
             else if ((ret = m_deletedID.Load(p_indexStreams[3], m_iDataBlockSize, m_iDataCapacity)) != ErrorCode::Success) return ret;
 

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -438,7 +438,7 @@ VectorIndex::CreateInstance(IndexAlgoType p_algo, VectorValueType p_valuetype)
 
 
 ErrorCode
-VectorIndex::LoadIndex(const std::string& p_loaderFilePath, std::shared_ptr<VectorIndex>& p_vectorIndex)
+VectorIndex::LoadIndex(const std::string& p_loaderFilePath, std::shared_ptr<VectorIndex>& p_vectorIndex, bool data_in_pm, bool graph_in_pm, std::string p_pm_path)
 {
     std::string folderPath(p_loaderFilePath);
     if (!folderPath.empty() && *(folderPath.rbegin()) != FolderSep) folderPath += FolderSep;
@@ -472,7 +472,7 @@ VectorIndex::LoadIndex(const std::string& p_loaderFilePath, std::shared_ptr<Vect
         handles.push_back(std::move(ptr));
     }
 
-    if ((ret = p_vectorIndex->LoadIndexData(handles)) != ErrorCode::Success) return ret;
+    if ((ret = p_vectorIndex->LoadIndexData(handles,data_in_pm,graph_in_pm,p_pm_path)) != ErrorCode::Success) return ret;
 
     if (iniReader.DoesSectionExist("MetaData"))
     {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
     message (FATAL_ERROR "Could no find openmp!")
 endif()
 
-find_package(Boost 1.67 COMPONENTS system thread serialization wserialization regex filesystem)
+find_package(Boost 1.66 COMPONENTS system thread serialization wserialization regex filesystem)
 if (Boost_FOUND)
     include_directories (${Boost_INCLUDE_DIR})
     link_directories (${Boost_LIBRARY_DIR})
@@ -89,6 +89,8 @@ if (Boost_FOUND)
 else()
     message (FATAL_ERROR "Could not find Boost >= 1.67!")
 endif()
+
+link_libraries(memkind)
 
 option(GPU "GPU" ON)
 option(LIBRARYONLY "LIBRARYONLY" OFF)

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT LIBRARYONLY)
       message (STATUS "BOOST_TEST_DYN_LINK")
     endif()
 
-    find_package(Boost 1.67 COMPONENTS system thread serialization wserialization regex filesystem unit_test_framework)
+    find_package(Boost 1.66 COMPONENTS system thread serialization wserialization regex filesystem unit_test_framework)
     if (Boost_FOUND)
         include_directories (${Boost_INCLUDE_DIR})
         link_directories (${Boost_LIBRARY_DIR})


### PR DESCRIPTION
We have added the PMem specific changes to the SPTAG code to allow IndexSearcher to utilize Optane PMem in AppDirect mode.

3 new command line arguments have been added IndexSearcher:
   -p, --pm_path <value>         Path to  Persistent Memory pool.
  -e, --vectors_in_pm <value>   Vectors will be stored in Persistent Memory pool.
  -g, --graph_in_pm <value>     Graph will be stored in Persistent Memory pool.

All these arguments are optional, and the code defaults to ram if these are not specified.

Only additional dependency is libmemkind.