### PR TITLE
Fix possible crash for large datasets

### DIFF
--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -288,7 +288,9 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
       
         // Auto-compute batch size based on available memory on the GPU
         size_t headVecSize = headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>);
-        size_t treeSize = 20*headRows;
+
+        int randSize = min((int)headRows, (int)1024)*48; // Memory used for GPU random number generator
+        size_t treeSize = 20*headRows + (size_t)randSize;
 
         size_t tailMemAvail = (freeMem*0.9) - (headVecSize+treeSize); // Only use 90% of total memory to be safe
 


### PR DESCRIPTION
Crash can occur for large datasets due to memory used for random number generator on GPU.  Fix reduces the memory used for this and takes it into account when computing number of batches to use.