### PR TITLE
GPU sort optimization and fix for Linux build

### DIFF
--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -83,7 +83,7 @@ inline bool fileexists(const TCHAR* path) {
 
 namespace SPTAG
 {
-#define ALIGN 32
+#define ALIGN_SPTAG 32
 
 typedef std::int32_t SizeType;
 typedef std::int32_t DimensionType;

--- a/AnnService/inc/Core/Common/BKTree.h
+++ b/AnnService/inc/Core/Common/BKTree.h
@@ -51,8 +51,8 @@ namespace SPTAG
             float(*fComputeDistance)(const T* pX, const T* pY, DimensionType length);
 
             KmeansArgs(int k, DimensionType dim, SizeType datasize, int threadnum, DistCalcMethod distMethod) : _K(k), _DK(k), _D(dim), _T(threadnum), _M(distMethod) {
-                centers = (T*)_mm_malloc(sizeof(T) * k * dim, ALIGN);
-                newTCenters = (T*)_mm_malloc(sizeof(T) * k * dim, ALIGN);
+                centers = (T*)_mm_malloc(sizeof(T) * k * dim, ALIGN_SPTAG);
+                newTCenters = (T*)_mm_malloc(sizeof(T) * k * dim, ALIGN_SPTAG);
                 counts = new SizeType[k];
                 newCenters = new float[threadnum * k * dim];
                 newCounts = new SizeType[threadnum * k];

--- a/AnnService/inc/Core/Common/Dataset.h
+++ b/AnnService/inc/Core/Common/Dataset.h
@@ -45,7 +45,7 @@ namespace SPTAG
                 if (data_ == nullptr || !transferOnwership_)
                 {
                     ownData = true;
-                    data = (T*)_mm_malloc(((size_t)rows) * cols * sizeof(T), ALIGN);
+                    data = (T*)_mm_malloc(((size_t)rows) * cols * sizeof(T), ALIGN_SPTAG);
                     if (data_ != nullptr) memcpy(data, data_, ((size_t)rows) * cols * sizeof(T));
                     else std::memset(data, -1, ((size_t)rows) * cols * sizeof(T));
                 }
@@ -98,7 +98,7 @@ namespace SPTAG
                 while (written < num) {
                     SizeType curBlockIdx = ((incRows + written) >> rowsInBlockEx);
                     if (curBlockIdx >= (SizeType)incBlocks.size()) {
-                        T* newBlock = (T*)_mm_malloc(((size_t)rowsInBlock + 1) * cols * sizeof(T), ALIGN);
+                        T* newBlock = (T*)_mm_malloc(((size_t)rowsInBlock + 1) * cols * sizeof(T), ALIGN_SPTAG);
                         if (newBlock == nullptr) return ErrorCode::MemoryOverFlow;
                         incBlocks.push_back(newBlock);
                     }
@@ -119,7 +119,7 @@ namespace SPTAG
                 while (written < num) {
                     SizeType curBlockIdx = (incRows + written) >> rowsInBlockEx;
                     if (curBlockIdx >= (SizeType)incBlocks.size()) {
-                        T* newBlock = (T*)_mm_malloc(sizeof(T) * (rowsInBlock + 1) * cols, ALIGN);
+                        T* newBlock = (T*)_mm_malloc(sizeof(T) * (rowsInBlock + 1) * cols, ALIGN_SPTAG);
                         if (newBlock == nullptr) return ErrorCode::MemoryOverFlow;
                         std::memset(newBlock, -1, sizeof(T) * (rowsInBlock + 1) * cols);
                         incBlocks.push_back(newBlock);

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -291,7 +291,8 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
       
         // Auto-compute batch size based on available memory on the GPU
         size_t headVecSize = headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>);
-        size_t treeSize = 20*headRows;
+        size_t randSize = (size_t)(min((int)headRows, (int)1024))*48; // Memory used for GPU random number generator
+        size_t treeSize = 20*headRows + randSize;
 
         size_t tailMemAvail = (freeMem*0.9) - (headVecSize+treeSize); // Only use 90% of total memory to be safe
 

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -7,6 +7,9 @@
 
 #include <cub/cub.cuh>
 #include <chrono>
+#include<thrust/execution_policy.h>
+#include<thrust/sort.h>
+#include <parallel/algorithm>
 
 using namespace SPTAG;
 using namespace std;
@@ -288,9 +291,7 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
       
         // Auto-compute batch size based on available memory on the GPU
         size_t headVecSize = headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>);
-
-        int randSize = min((int)headRows, (int)1024)*48; // Memory used for GPU random number generator
-        size_t treeSize = 20*headRows + (size_t)randSize;
+        size_t treeSize = 20*headRows;
 
         size_t tailMemAvail = (freeMem*0.9) - (headVecSize+treeSize); // Only use 90% of total memory to be safe
 
@@ -457,6 +458,113 @@ LOG(SPTAG::Helper::LogLevel::LL_Debug, "Tree %d complete, time to build tree:%.2
     LOG(SPTAG::Helper::LogLevel::LL_Info, "Mam alloc time:%0.2lf, GPU time to build index:%.2lf, Memory free time:%.2lf\n", ((double)std::chrono::duration_cast<std::chrono::seconds>(ssd_t1-premem_t).count()) + ((double)std::chrono::duration_cast<std::chrono::milliseconds>(ssd_t1-premem_t).count())/1000, ((double)std::chrono::duration_cast<std::chrono::seconds>(ssd_t2-ssd_t1).count()) + ((double)std::chrono::duration_cast<std::chrono::milliseconds>(ssd_t2-ssd_t1).count())/1000, ((double)std::chrono::duration_cast<std::chrono::seconds>(ssd_t3-ssd_t2).count()) + ((double)std::chrono::duration_cast<std::chrono::milliseconds>(ssd_t3-ssd_t2).count())/1000);
 
 }
+
+__host__ __device__ struct GPUEdge
+{
+    SizeType node;
+    float distance;
+    SizeType tonode;
+    __host__ __device__ GPUEdge() : node(MaxSize), distance(FLT_MAX/10.0), tonode(MaxSize) {}
+};
+
+
+struct GPU_EdgeCompare {
+    bool operator()(const GPUEdge& a, int b) const
+    {
+        return a.node < b;
+    };
+
+    bool operator()(int a, const GPUEdge& b) const
+    {
+        return a < b.node;
+    };
+
+    __host__ __device__ bool operator()(const GPUEdge& a, const GPUEdge& b) {
+        if (a.node == b.node)
+        {
+            if (a.distance == b.distance)
+            {
+                return a.tonode < b.tonode;
+            }
+
+            return a.distance < b.distance;
+        }
+        return a.node < b.node;
+    }
+} gpu_edgeComparer;
+
+void GPU_SortSelections(std::vector<Edge>* selections) {
+
+  size_t N = selections->size();
+
+  size_t freeMem, totalMem;
+  CUDA_CHECK(cudaMemGetInfo(&freeMem, &totalMem));
+
+// Maximum number of elements that can be sorted on GPU
+  size_t sortBatchSize = (size_t)(freeMem*0.9 / sizeof(GPUEdge))/2; 
+
+  std::vector<GPUEdge>* new_selections = reinterpret_cast<std::vector<GPUEdge>*>(selections);
+
+  int num_batches = (N + (sortBatchSize-1)) / sortBatchSize;
+
+  LOG(SPTAG::Helper::LogLevel::LL_Info, "Sorting final results. Size of result:%ld elements = %0.2lf GB, Available GPU memory:%0.2lf, sorting in %d batches\n", N, ((double)(N*sizeof(GPUEdge))/1000000000.0), ((double)freeMem)/1000000000.0, num_batches);
+
+  int batchNum=0;
+
+  GPUEdge* merge_mem;
+  if(num_batches > 1) {
+    merge_mem = new GPUEdge[N];
+  }
+
+  LOG(SPTAG::Helper::LogLevel::LL_Debug, "Allocating %ld bytes on GPU for sorting\n", sortBatchSize*sizeof(GPUEdge));
+  GPUEdge* d_selections;
+  CUDA_CHECK(cudaMalloc(&d_selections, sortBatchSize*sizeof(GPUEdge)));
+
+  for(size_t startIdx = 0; startIdx < N; startIdx += sortBatchSize) {
+    
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    size_t batchSize = sortBatchSize;
+    if(startIdx + batchSize > N) {
+      batchSize = N - startIdx;
+    }
+    LOG(SPTAG::Helper::LogLevel::LL_Debug, "Sorting batch id:%ld, size:%ld\n", startIdx, batchSize);
+
+    GPUEdge* batchPtr = &(new_selections->data()[startIdx]);
+    
+    CUDA_CHECK(cudaMemcpy(d_selections, batchPtr, batchSize*sizeof(GPUEdge), cudaMemcpyHostToDevice));
+    try {
+      thrust::sort(thrust::device, d_selections, d_selections+batchSize, gpu_edgeComparer);
+    }
+    catch (thrust::system_error &e){
+      LOG(SPTAG::Helper::LogLevel::LL_Info, "Error: %s \n",e.what());
+    }
+
+    CUDA_CHECK(cudaMemcpy(batchPtr, d_selections, batchSize*sizeof(GPUEdge), cudaMemcpyDeviceToHost));
+
+    auto t2 = std::chrono::high_resolution_clock::now();
+
+    // For all batches after the first, merge into the final output
+    if(startIdx > 0) {
+      std::merge(new_selections->data(), batchPtr, batchPtr, &batchPtr[batchSize], merge_mem, gpu_edgeComparer);
+
+// For faster merging on Linux systems, can use below instead of std::merge (above)
+//      __gnu_parallel::merge(new_selections->data(), batchPtr, batchPtr, &batchPtr[batchSize], merge_mem, gpu_edgeComparer);
+ 
+      memcpy(new_selections->data(), merge_mem, (startIdx+batchSize)*sizeof(GPUEdge));
+    }
+    
+    auto t3 = std::chrono::high_resolution_clock::now();
+
+    LOG(SPTAG::Helper::LogLevel::LL_Debug, "Sort batch %d - GPU transfer/sort time:%0.2lf, CPU merge time:%.2lf\n", batchNum, ((double)std::chrono::duration_cast<std::chrono::seconds>(t2-t1).count()) + ((double)std::chrono::duration_cast<std::chrono::milliseconds>(t2-t1).count())/1000, ((double)std::chrono::duration_cast<std::chrono::seconds>(t3-t2).count()) + ((double)std::chrono::duration_cast<std::chrono::milliseconds>(t3-t2).count())/1000);
+    batchNum++;
+  }
+  if(num_batches > 1) {
+    delete merge_mem;
+  }
+}
+
+
 
 /*************************************************************************************************
  * Deprecated code from Hybrid CPU/GPU SSD Index builder

--- a/AnnService/inc/Core/SearchResult.h
+++ b/AnnService/inc/Core/SearchResult.h
@@ -26,14 +26,6 @@ namespace SPTAG
         }
     };
 
-    struct Edge
-    {
-        SizeType node;
-        float distance;
-        SizeType tonode;
-        Edge() : node(MaxSize), distance(MaxDist), tonode(MaxSize) {}
-    };
-
     struct BasicResult
     {
         SizeType VID;

--- a/AnnService/inc/Core/VectorIndex.h
+++ b/AnnService/inc/Core/VectorIndex.h
@@ -13,6 +13,16 @@
 
 namespace SPTAG
 {
+
+struct Edge
+{
+    SizeType node;
+    float distance;
+    SizeType tonode;
+    Edge() : node(MaxSize), distance(MaxDist), tonode(MaxSize) {}
+};
+
+
 class IAbortOperation
 {
 public:
@@ -81,6 +91,8 @@ public:
     virtual ErrorCode SearchIndex(const void* p_vector, int p_vectorCount, int p_neighborCount, bool p_withMeta, BasicResult* p_results) const;
 
     virtual void ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::unordered_set<int>& exceptIDS, int candidateNum, Edge* selections, int replicaCount, int numThreads, int numTrees, int leafSize, float RNGFactor, int numGPUs);
+
+    static void SortSelections(std::vector<Edge>* selections);
 
     virtual std::string GetParameter(const std::string& p_param) const;
     virtual ErrorCode SetParameter(const std::string& p_param, const std::string& p_value);

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -633,33 +633,6 @@ std::uint64_t VectorIndex::EstimatedMemoryUsage(std::uint64_t p_vectorCount, Dim
 #if defined(GPU)
 
 #include "inc/Core/Common/cuda/TailNeighbors.hxx"
-struct test_EdgeCompare {
-    bool operator()(const Edge& a, int b) const
-    {
-        return a.node < b;
-    };
-
-    bool operator()(int a, const Edge& b) const
-    {
-        return a < b.node;
-    };
-
-    __host__ __device__ bool operator()(const Edge& a, const Edge& b) {
-        if (a.node == b.node)
-        {
-            if (a.distance == b.distance)
-            {
-                return a.tonode < b.tonode;
-            }
-
-            return a.distance < b.distance;
-        }
-        return a.node < b.node;
-    }
-} g_edgeComparer;
-
-
-
 
 void VectorIndex::SortSelections(std::vector<Edge>* selections) {
   LOG(Helper::LogLevel::LL_Debug, "Starting sort of final input on GPU\n");
@@ -774,10 +747,10 @@ struct EdgeCompare
 
         return a.node < b.node;
     };
-} test_edgeComparer;
+} g_edgeComparer;
 
 void VectorIndex::SortSelections(std::vector<Edge>* selections) {
-  std::sort(selections->begin(), selections->end(), test_edgeComparer);
+  std::sort(selections->begin(), selections->end(), g_edgeComparer);
 }
 
 void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::unordered_set<int>& exceptIDS, int candidateNum, Edge* selections, int replicaCount, int numThreads, int numTrees, int leafSize, float RNGFactor, int numGPUs)

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -25,6 +25,8 @@ std::shared_ptr<Helper::Logger> SPTAG::g_pLogger(new Helper::SimpleLogger(Helper
 std::shared_ptr<Helper::Logger> SPTAG::g_pLogger(new Helper::SimpleLogger(Helper::LogLevel::LL_Info));
 #endif
 
+
+
 std::shared_ptr<Helper::DiskPriorityIO>(*SPTAG::f_createIO)() = []() -> std::shared_ptr<Helper::DiskPriorityIO> { return std::shared_ptr<Helper::DiskPriorityIO>(new Helper::SimpleFileIO()); };
 
 VectorIndex::VectorIndex()
@@ -626,9 +628,45 @@ std::uint64_t VectorIndex::EstimatedMemoryUsage(std::uint64_t p_vectorCount, Dim
     return ret;
 }
 
+
+
 #if defined(GPU)
 
 #include "inc/Core/Common/cuda/TailNeighbors.hxx"
+struct test_EdgeCompare {
+    bool operator()(const Edge& a, int b) const
+    {
+        return a.node < b;
+    };
+
+    bool operator()(int a, const Edge& b) const
+    {
+        return a < b.node;
+    };
+
+    __host__ __device__ bool operator()(const Edge& a, const Edge& b) {
+        if (a.node == b.node)
+        {
+            if (a.distance == b.distance)
+            {
+                return a.tonode < b.tonode;
+            }
+
+            return a.distance < b.distance;
+        }
+        return a.node < b.node;
+    }
+} g_edgeComparer;
+
+
+
+
+void VectorIndex::SortSelections(std::vector<Edge>* selections) {
+  LOG(Helper::LogLevel::LL_Debug, "Starting sort of final input on GPU\n");
+  GPU_SortSelections(selections);
+}
+
+
 
 void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::unordered_set<int>& exceptIDS, int candidateNum, Edge* selections, int replicaCount, int numThreads, int numTrees, int leafSize, float RNGFactor, int numGPUs)
 {
@@ -674,6 +712,7 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
                 resIdx++;
             }
         }
+
         delete[] results;
     }
     else {
@@ -708,6 +747,38 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
     }
 }
 #else
+
+struct EdgeCompare
+{
+    bool operator()(const Edge& a, int b) const
+    {
+        return a.node < b;
+    };
+
+    bool operator()(int a, const Edge& b) const
+    {
+        return a < b.node;
+    };
+
+    bool operator()(const Edge& a, const Edge& b) const
+    {
+        if (a.node == b.node)
+        {
+            if (a.distance == b.distance)
+            {
+                return a.tonode < b.tonode;
+            }
+
+            return a.distance < b.distance;
+        }
+
+        return a.node < b.node;
+    };
+} test_edgeComparer;
+
+void VectorIndex::SortSelections(std::vector<Edge>* selections) {
+  std::sort(selections->begin(), selections->end(), test_edgeComparer);
+}
 
 void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::unordered_set<int>& exceptIDS, int candidateNum, Edge* selections, int replicaCount, int numThreads, int numTrees, int leafSize, float RNGFactor, int numGPUs)
 {


### PR DESCRIPTION
Code to enable using GPU for final result sort, and additional fixes for Linux build support, including:
- Changed `ALIGN` to `ALIGN_SPTAG` to prevent interference with other libraries
- Moved sort definition and Edge and EdgeComparer structures to different file
- Includes use of Thrust library for fast GPU sorting and std::merge for merging large sorted results