### PR TITLE
Reduce CPU memory usage for GPU SSD index build

### DIFF
--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -34,7 +34,14 @@ class QueryGroup {
  * is already created and populated based on the head vectors.
 ***********************************************************************************/
 template<typename T, typename KEY_T, typename SUMTYPE, int Dim, int BLOCK_DIM>
-__global__ void findTailRNG(Point<T,SUMTYPE,Dim>* headPoints, Point<T,SUMTYPE,Dim>* tailPoints, TPtree<T,KEY_T,SUMTYPE,Dim>* tptree, int KVAL, DistPair<SUMTYPE>* results, int metric, size_t numTails, int numHeads, QueryGroup* groups) {
+__global__ void findTailRNG(Point<T,SUMTYPE,Dim>* headPoints, Point<T,SUMTYPE,Dim>* tailPoints, TPtree<T,KEY_T,SUMTYPE,Dim>* tptree, int KVAL, DistPair<SUMTYPE>* results, int metric, size_t numTails, int numHeads, QueryGroup* groups, bool print) {
+
+  if(threadIdx.x==0 && blockIdx.x==0 && print) {
+printf("headPoint 0: id:%d, coords:%f, %f, %f, %f\n", headPoints[0].id, headPoints[0].coords[0], headPoints[0].coords[1], headPoints[0].coords[2], headPoints[0].coords[3]);
+printf("headPoint %d: id:%d, coords:%f, %f, %f, %f\n", numHeads-1, headPoints[numHeads-1].id, headPoints[numHeads-1].coords[0], headPoints[numHeads-1].coords[1], headPoints[numHeads-1].coords[2], headPoints[0].coords[3]);
+printf("tailPoint 0: id:%d, coords:%f, %f, %f, %f\n", tailPoints[0].id, tailPoints[0].coords[0], tailPoints[0].coords[1], tailPoints[0].coords[2], tailPoints[0].coords[3]);
+printf("tailPoint %ld: id:%d, coords:%f, %f, %f, %f\n", numTails-1, tailPoints[numTails-1].id, tailPoints[numTails-1].coords[0], tailPoints[numTails-1].coords[1], tailPoints[numTails-1].coords[2], tailPoints[numTails-1].coords[3]);
+  }
 
   extern __shared__ char sharememory[];
 
@@ -166,7 +173,6 @@ __global__ void assign_queries_to_group(QueryGroup* groups, TPtree<T,KEY_T,SUMTY
     idx_in_leaf = atomicAdd(&(groups->sizes[leafId]), 1);   
     groups->query_ids[groups->offsets[leafId]+idx_in_leaf] = qidx;
   }
-  
 }
 
 // Gets the list of queries that are to be searched into each leaf.  The QueryGroup structure uses the memory
@@ -198,6 +204,67 @@ __host__ void get_query_groups(QueryGroup* groups, TPtree<T,KEY_T,SUMTYPE,MAX_DI
   delete[] h_offsets;
 }
     
+#define COPY_BUFF_SIZE 1024
+
+// Function to extract head vectors from list and copy them to GPU, using only a small CPU buffer.
+// This reduces the CPU memory usage needed to convert all vectors into the Point structure used by GPU
+template<typename T, typename SUMTYPE, int MAX_DIM>
+void extractAndCopyHeadPoints(Point<T,SUMTYPE,MAX_DIM>* headPointBuffer, T* vectors, SPTAG::VectorIndex* headIndex, Point<T,SUMTYPE,MAX_DIM>* d_headPoints, size_t headRows, int dim) {
+
+  size_t copy_size = COPY_BUFF_SIZE;
+  for(size_t i=0; i<headRows; i+=COPY_BUFF_SIZE) {
+    if(headRows-i < COPY_BUFF_SIZE) copy_size = headRows-i; // Last copy may be smaller
+
+    for(int j=0; j<copy_size; j++) {
+      headPointBuffer[j].loadChunk((T*)headIndex->GetSample(i+j), dim);
+      headPointBuffer[j].id = i+j;
+    }
+    
+    CUDA_CHECK(cudaMemcpy(d_headPoints+i, headPointBuffer, copy_size*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice));
+  }
+}
+
+// Extracts tail vectors from vector list and copy them to GPU, using only a small CPU buffer for conversion.
+// Returns number of tail vectors copied to GPU
+template<typename T, typename SUMTYPE, int MAX_DIM>
+size_t extractAndCopyTailPoints(Point<T,SUMTYPE,MAX_DIM>* pointBuffer, T* vectors, Point<T,SUMTYPE,MAX_DIM>* d_tailPoints, size_t size, std::unordered_set<int>& headVectorIDS, int dim, size_t batch_offset) {
+
+  size_t copy_size = COPY_BUFF_SIZE;
+  size_t write_idx=0;
+  int tailIdx;
+
+  for(int i=0; i<size; i+=COPY_BUFF_SIZE) {
+    if(size-i < COPY_BUFF_SIZE) copy_size = size-i; // Last copy may be smaller
+     
+    // If given head IDS, need to filter out head vectors and copy only tails
+/*
+    if(headVectorIDS.size() != 0) {
+printf("A - Copying %d tail vectors!\n", copy_size);
+      tailIdx=0;
+      for(int j=0; j<copy_size; ++j) {
+        if(headVectorIDS.count(i+j) == 0) {
+          pointBuffer[tailIdx].loadChunk(&vectors[(i+j)*dim], dim);
+          pointBuffer[tailIdx].id = i+j;
+        //  tailIdx++;
+        }
+          tailIdx++;
+      }
+      CUDA_CHECK(cudaMemcpy(d_tailPoints+write_idx, pointBuffer, tailIdx*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice));
+      write_idx += tailIdx;
+    }
+    else {
+*/
+      for(int j=0; j<copy_size; ++j) {
+        pointBuffer[j].loadChunk(&vectors[(i+j)*dim], dim);
+        pointBuffer[j].id = i+j+batch_offset;
+//if(headVectorIDS.count(i+j) != 0) pointBuffer[j].id = -1;
+      }
+      CUDA_CHECK(cudaMemcpy(d_tailPoints+i, pointBuffer, copy_size*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice));
+      write_idx+=copy_size;
+//    }
+  }
+  return write_idx;
+}
 
 template<typename T, typename KEY_T, typename SUMTYPE, int MAX_DIM>
 void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* headIndex, std::unordered_set<int>& headVectorIDS, int dim, DistPair<SUMTYPE>* results, int RNG_SIZE, int numThreads, int NUM_TREES, int LEAF_SIZE, int metric, int NUM_GPUS) {
@@ -226,20 +293,43 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
     }
     int TPTlevels = (int)std::log2(headRows/LEAF_SIZE);
 
-    Point<T,SUMTYPE,MAX_DIM>* headPoints;
+    // Buffers to shuttle vectors from index structure to GPU
+    Point<T,SUMTYPE,MAX_DIM>* pointBuffer;
+//    Point<T,SUMTYPE,MAX_DIM>* tailPointBuffer;
+    pointBuffer = new Point<T,SUMTYPE,MAX_DIM>[COPY_BUFF_SIZE];
+//    tailPointBuffer = new Point<T,SUMTYPE,MAX_DIM>[COPY_BUFF_SIZE];
+
+
+//    Point<T,SUMTYPE,MAX_DIM>* headPoints;
+//    headPoints = new Point<T,SUMTYPE,MAX_DIM>[headRows];
     Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
-    headPoints = new Point<T,SUMTYPE,MAX_DIM>[headRows];
     tailPoints = new Point<T,SUMTYPE,MAX_DIM>[tailRows];
 
     // If headVectors not given, extract from headIndex and use all vectors as tails
-    extractHeadPointsFromIndex<T,SUMTYPE,MAX_DIM>(vectors, headIndex, headPoints, dim);
+//    extractHeadPointsFromIndex<T,SUMTYPE,MAX_DIM>(vectors, headIndex, headPoints, dim);
+/*
     if(headVectorIDS.size() == 0) {
         extractFullVectorPoints<T,SUMTYPE,MAX_DIM>(vectors, tailPoints, N, dim);
     }
     else {
         extractTailPoints<T,SUMTYPE,MAX_DIM>(vectors, tailPoints, N, headVectorIDS, dim);
     }
+*/
+
+    std::vector<size_t> pointsPerGPU(NUM_GPUS);
+    std::vector<size_t> GPUPointOffset(NUM_GPUS);
+    for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+        pointsPerGPU[gpuNum] = N / NUM_GPUS;
+        if(N % NUM_GPUS > gpuNum) pointsPerGPU[gpuNum]++;
+    }
+    GPUPointOffset[0] = 0;
+    LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU 0: points:%lu, offset:%lu\n", pointsPerGPU[0], GPUPointOffset[0]);
+    for(int gpuNum=1; gpuNum < NUM_GPUS; ++gpuNum) {
+        GPUPointOffset[gpuNum] = GPUPointOffset[gpuNum-1] + pointsPerGPU[gpuNum-1];
+        LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU %d: points:%lu, offset:%lu\n", gpuNum, pointsPerGPU[gpuNum], GPUPointOffset[gpuNum]);
+    }
   
+/*
     // Get number and offset of tail vectors to be assigned to each GPU
     std::vector<size_t> tailsPerGPU(NUM_GPUS);
     std::vector<size_t> GPUOffset(NUM_GPUS);
@@ -249,11 +339,11 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
     }
     GPUOffset[0] = 0;
     LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU 0: tails:%lu, offset:%lu\n", tailsPerGPU[0], GPUOffset[0]);
-    LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU 0: tails:%lu, offset:%lu\n", tailsPerGPU[0], GPUOffset[0]);
     for(int gpuNum=1; gpuNum < NUM_GPUS; ++gpuNum) {
         GPUOffset[gpuNum] = GPUOffset[gpuNum-1] + tailsPerGPU[gpuNum-1];
         LOG(SPTAG::Helper::LogLevel::LL_Debug, "GPU %d: tails:%lu, offset:%lu\n", gpuNum, tailsPerGPU[gpuNum], GPUOffset[gpuNum]);
     }
+*/
 
     // Streams and memory pointers for each GPU
     std::vector<cudaStream_t> streams(NUM_GPUS);
@@ -299,15 +389,16 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
         // memory needed for points, results, and query reorder mem
         int maxEltsPerBatch = tailMemAvail / (sizeof(Point<T,SUMTYPE,MAX_DIM>) + RNG_SIZE*sizeof(DistPair<SUMTYPE>) + 2*sizeof(int));
 
-        BATCH_SIZE[gpuNum] = min(maxEltsPerBatch, (int)(tailsPerGPU[gpuNum]));
+//        BATCH_SIZE[gpuNum] = min(maxEltsPerBatch, (int)(tailsPerGPU[gpuNum]));
+        BATCH_SIZE[gpuNum] = min(maxEltsPerBatch, (int)(pointsPerGPU[gpuNum]));
 
        // If GPU memory is insufficient or so limited that we need so many batches it becomes inefficient, return error
-        if(BATCH_SIZE[gpuNum] == 0 || ((int)tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum] > 10000) {
+        if(BATCH_SIZE[gpuNum] == 0 || ((int)pointsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum] > 10000) {
             LOG(SPTAG::Helper::LogLevel::LL_Error, "Insufficient GPU memory to build SSD index on GPU %d.  Available GPU memory:%lu MB, Head index requires:%lu MB, leaving a maximum batch size of %d elements, which is too small to run efficiently.\n", gpuNum, (freeMem)/1000000, (headVecSize+treeSize)/1000000, maxEltsPerBatch);
             exit(1);
         }
   
-        LOG(SPTAG::Helper::LogLevel::LL_Info, "Memory for head vectors:%lu MiB, Memory for TP trees:%lu MiB, Memory left for tail vectors:%lu MiB, total tail vectors:%lu, batch size:%d, total batches:%d\n", headVecSize/1000000, treeSize/1000000, tailMemAvail/1000000, tailsPerGPU[gpuNum], BATCH_SIZE[gpuNum], (((BATCH_SIZE[gpuNum]-1)+tailsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum]));
+        LOG(SPTAG::Helper::LogLevel::LL_Info, "Memory for head vectors:%lu MiB, Memory for TP trees:%lu MiB, Memory left for tail vectors:%lu MiB, total tail vectors:%lu, batch size:%d, total batches:%d\n", headVecSize/1000000, treeSize/1000000, tailMemAvail/1000000, pointsPerGPU[gpuNum], BATCH_SIZE[gpuNum], (((BATCH_SIZE[gpuNum]-1)+pointsPerGPU[gpuNum]) / BATCH_SIZE[gpuNum]));
   
         LOG(SPTAG::Helper::LogLevel::LL_Debug, "Allocating GPU memory: tail points:%lu MiB, head points:%lu MiB, results:%lu MiB, TPT:%lu MiB, Total:%lu MiB\n", (BATCH_SIZE[gpuNum]*sizeof(Point<T,SUMTYPE,MAX_DIM>))/1000000, (headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>))/1000000, (BATCH_SIZE[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>))/1000000, (sizeof(TPtree<T,KEY_T,SUMTYPE, MAX_DIM>))/1000000, ((BATCH_SIZE[gpuNum]+headRows)*sizeof(Point<T,SUMTYPE,MAX_DIM>) + (BATCH_SIZE[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>)) + (sizeof(TPtree<T,KEY_T,SUMTYPE,MAX_DIM>)))/1000000);
 
@@ -328,16 +419,19 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
         CUDA_CHECK(cudaMalloc(&d_queryGroups[gpuNum], sizeof(QueryGroup)));
 
         // Copy head points to GPU
-        CUDA_CHECK(cudaMemcpy(d_headPoints[gpuNum], headPoints, headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice));
+//        CUDA_CHECK(cudaMemcpy(d_headPoints[gpuNum], headPoints, headRows*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice));
+        extractAndCopyHeadPoints<T,SUMTYPE,MAX_DIM>(pointBuffer, vectors, headIndex, d_headPoints[gpuNum], headRows, dim);
 
     } // End loop to set up memory on each GPU
 
-    delete[] headPoints; // headPoints copied to GPU, no longer need on CPU
+//    delete[] headPointBuffer; // headPoints copied to GPU, no longer need on CPU
+//    delete[] headPoints; // headPoints copied to GPU, no longer need on CPU
 
     const int NUM_THREADS = 32;
     int NUM_BLOCKS = min((int)(BATCH_SIZE[0]/NUM_THREADS), 10240);
 
     std::vector<size_t> curr_batch_size(NUM_GPUS);
+    std::vector<size_t> tail_batch_size(NUM_GPUS);
     std::vector<size_t> offset(NUM_GPUS);
     for(int gpuNum=0; gpuNum<NUM_GPUS; ++gpuNum) {
         offset[gpuNum] = 0;
@@ -348,30 +442,31 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
     bool done = false; 
     while(!done) { // Continue until all GPUs have completed all of their batches 
 
-
         // Prep next batch for each GPU
         for(int gpuNum=0; gpuNum<NUM_GPUS; ++gpuNum) {
             curr_batch_size[gpuNum] = BATCH_SIZE[gpuNum];
             // Check if final batch is smaller than previous
-            if(offset[gpuNum]+BATCH_SIZE[gpuNum] > tailsPerGPU[gpuNum]) {
-                curr_batch_size[gpuNum] = tailsPerGPU[gpuNum]-offset[gpuNum];
+            if(offset[gpuNum]+BATCH_SIZE[gpuNum] > pointsPerGPU[gpuNum]) {
+                curr_batch_size[gpuNum] = pointsPerGPU[gpuNum]-offset[gpuNum];
             }
-            LOG(SPTAG::Helper::LogLevel::LL_Info, "GPU %d - starting batch with offset:%lu, size:%lu, TailRows:%lld\n", gpuNum, offset[gpuNum], curr_batch_size[gpuNum], tailsPerGPU[gpuNum]);
+            LOG(SPTAG::Helper::LogLevel::LL_Info, "GPU %d - starting batch with GPUOffset:%lu, offset:%lu, total offset:%lu, size:%lu, TailRows:%lld\n", gpuNum, GPUPointOffset[gpuNum], offset[gpuNum], GPUPointOffset[gpuNum]+offset[gpuNum], curr_batch_size[gpuNum], pointsPerGPU[gpuNum]);
     
             cudaSetDevice(gpuNum);
 
             // Copy next batch of tail vectors to corresponding GPU
-            resultErr = cudaMemcpyAsync(d_tailPoints[gpuNum], &tailPoints[GPUOffset[gpuNum]+offset[gpuNum]], curr_batch_size[gpuNum]*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice, streams[gpuNum]);
+//            resultErr = cudaMemcpyAsync(d_tailPoints[gpuNum], &tailPoints[GPUOffset[gpuNum]+offset[gpuNum]], curr_batch_size[gpuNum]*sizeof(Point<T,SUMTYPE,MAX_DIM>), cudaMemcpyHostToDevice, streams[gpuNum]);
+            tail_batch_size[gpuNum] = extractAndCopyTailPoints<T,SUMTYPE,MAX_DIM>(pointBuffer, &vectors[(GPUPointOffset[gpuNum]+offset[gpuNum])*dim], d_tailPoints[gpuNum], curr_batch_size[gpuNum], headVectorIDS, dim, GPUPointOffset[gpuNum]+offset[gpuNum]);
+            
             LOG(SPTAG::Helper::LogLevel::LL_Debug, "Copied %lu tail points to GPU - kernel status:%d\n", curr_batch_size[gpuNum], resultErr);
 
             // Initialize and copy results for batch to each GPU
             for(int i=0; i<curr_batch_size[gpuNum]*RNG_SIZE; i++) {
-                results[(GPUOffset[gpuNum] + offset[gpuNum])*RNG_SIZE + i].idx=-1;
-                results[(GPUOffset[gpuNum] + offset[gpuNum])*RNG_SIZE + i].dist=INFTY<SUMTYPE>();
+                results[(GPUPointOffset[gpuNum] + offset[gpuNum])*RNG_SIZE + i].idx=-1;
+                results[(GPUPointOffset[gpuNum] + offset[gpuNum])*RNG_SIZE + i].dist=INFTY<SUMTYPE>();
             }
-            resultErr = cudaMemcpyAsync(d_results[gpuNum], &results[(GPUOffset[gpuNum]+offset[gpuNum])*RNG_SIZE], curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), cudaMemcpyHostToDevice, streams[gpuNum]);
+            resultErr = cudaMemcpyAsync(d_results[gpuNum], &results[(GPUPointOffset[gpuNum]+offset[gpuNum])*RNG_SIZE], curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), cudaMemcpyHostToDevice, streams[gpuNum]);
 
-            LOG(SPTAG::Helper::LogLevel::LL_Debug, "Copying initialized result list to GPU - batch size:%lu - replica count:%d, copy bytes:%lu, GPU offset:%lu, total result offset:%lu, - kernel status:%d\n", curr_batch_size[gpuNum], RNG_SIZE, curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), GPUOffset[gpuNum], (GPUOffset[gpuNum]+offset[gpuNum])*RNG_SIZE, resultErr);
+            LOG(SPTAG::Helper::LogLevel::LL_Debug, "Copying initialized result list to GPU - batch size:%lu - replica count:%d, copy bytes:%lu, GPU offset:%lu, total result offset:%lu, - kernel status:%d\n", curr_batch_size[gpuNum], RNG_SIZE, curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), GPUPointOffset[gpuNum], (GPUPointOffset[gpuNum]+offset[gpuNum])*RNG_SIZE, resultErr);
         }
 
 
@@ -403,8 +498,9 @@ auto t2 = std::chrono::high_resolution_clock::now();
 
             // Call main kernel on each GPU
             for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
+printf("gpu:%d\n", gpuNum);
                 CUDA_CHECK(cudaSetDevice(gpuNum));
-                findTailRNG<T,KEY_T,SUMTYPE,MAX_DIM,NUM_THREADS><<<NUM_BLOCKS, NUM_THREADS, sizeof(DistPair<SUMTYPE>)*RNG_SIZE*NUM_THREADS, streams[gpuNum]>>>(d_headPoints[gpuNum], d_tailPoints[gpuNum], d_tptree[gpuNum], RNG_SIZE, d_results[gpuNum], metric, (size_t)curr_batch_size[gpuNum], headRows, d_queryGroups[gpuNum]);
+                findTailRNG<T,KEY_T,SUMTYPE,MAX_DIM,NUM_THREADS><<<NUM_BLOCKS, NUM_THREADS, sizeof(DistPair<SUMTYPE>)*RNG_SIZE*NUM_THREADS, streams[gpuNum]>>>(d_headPoints[gpuNum], d_tailPoints[gpuNum], d_tptree[gpuNum], RNG_SIZE, d_results[gpuNum], metric, (size_t)curr_batch_size[gpuNum], headRows, d_queryGroups[gpuNum], tree_id==0);
             }
 
             CUDA_CHECK(cudaDeviceSynchronize());
@@ -420,7 +516,9 @@ LOG(SPTAG::Helper::LogLevel::LL_Debug, "Tree %d complete, time to build tree:%.2
 
         // Copy results of batch from each GPU to CPU result set
         for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
-            CUDA_CHECK(cudaMemcpy(&results[(GPUOffset[gpuNum]+offset[gpuNum])*RNG_SIZE], d_results[gpuNum], curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), cudaMemcpyDeviceToHost));
+            CUDA_CHECK(cudaSetDevice(gpuNum));
+printf("gpu:%d, copying results size %lu to results offset:%d*%d=%d\n", gpuNum, curr_batch_size[gpuNum], GPUPointOffset[gpuNum]+offset[gpuNum],RNG_SIZE, (GPUPointOffset[gpuNum]+offset[gpuNum])*RNG_SIZE);
+            CUDA_CHECK(cudaMemcpy(&results[(GPUPointOffset[gpuNum]+offset[gpuNum])*RNG_SIZE], d_results[gpuNum], curr_batch_size[gpuNum]*RNG_SIZE*sizeof(DistPair<SUMTYPE>), cudaMemcpyDeviceToHost));
         }
         LOG(SPTAG::Helper::LogLevel::LL_Debug, "Finished copying all batch results back to CPU\n");
 
@@ -428,11 +526,37 @@ LOG(SPTAG::Helper::LogLevel::LL_Debug, "Tree %d complete, time to build tree:%.2
         done=true;
         for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
             offset[gpuNum] += curr_batch_size[gpuNum];
-            if(offset[gpuNum] < tailsPerGPU[gpuNum]) {
+            if(offset[gpuNum] < pointsPerGPU[gpuNum]) {
                 done=false;
             }
         }
     } // Batches loop (while !done)
+
+printf("0 - ");
+for(int i=0; i<8; i++) {
+printf("%d, ", results[i].idx);
+}
+printf("\n");
+printf("591756 - ");
+for(int i=0; i<8; i++) {
+printf("%d, ", results[(591756*8)+i].idx);
+}
+printf("\n");
+printf("591757 - ");
+for(int i=0; i<8; i++) {
+printf("%d, ", results[591757*8 + i].idx);
+}
+printf("\n");
+printf("1000000 - ");
+for(int i=0; i<8; i++) {
+printf("%d, ", results[8000000 + i].idx);
+}
+printf("\n");
+printf("1183513 - ");
+for(int i=0; i<8; i++) {
+printf("%d, ", results[1183513*8 + i].idx);
+}
+printf("\n");
 
     auto ssd_t2 = std::chrono::high_resolution_clock::now();
 
@@ -446,6 +570,7 @@ LOG(SPTAG::Helper::LogLevel::LL_Debug, "Tree %d complete, time to build tree:%.2
         CUDA_CHECK(cudaFree(d_tptree[gpuNum]));
         delete tptree[gpuNum];
     }
+    delete[] pointBuffer;
     delete[] tailPoints;
 
     delete[] d_headPoints;

--- a/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
+++ b/AnnService/inc/Core/Common/cuda/TailNeighbors.hxx
@@ -302,8 +302,8 @@ void getTailNeighborsTPT(T* vectors, SPTAG::SizeType N, SPTAG::VectorIndex* head
 
 //    Point<T,SUMTYPE,MAX_DIM>* headPoints;
 //    headPoints = new Point<T,SUMTYPE,MAX_DIM>[headRows];
-    Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
-    tailPoints = new Point<T,SUMTYPE,MAX_DIM>[tailRows];
+//    Point<T,SUMTYPE,MAX_DIM>* tailPoints; 
+//    tailPoints = new Point<T,SUMTYPE,MAX_DIM>[tailRows];
 
     // If headVectors not given, extract from headIndex and use all vectors as tails
 //    extractHeadPointsFromIndex<T,SUMTYPE,MAX_DIM>(vectors, headIndex, headPoints, dim);
@@ -571,7 +571,7 @@ printf("\n");
         delete tptree[gpuNum];
     }
     delete[] pointBuffer;
-    delete[] tailPoints;
+//    delete[] tailPoints;
 
     delete[] d_headPoints;
     delete[] d_tailPoints;

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -682,10 +682,10 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
                     selections[vecOffset + resNum].node = results[resOffset + resNum].idx;
                     selections[vecOffset + resNum].distance = (float)results[resOffset + resNum].dist;
                 }
-                resIdx++;
+//                resIdx++;
             }
+            resIdx++;
         }
-
         delete[] results;
     }
     else {
@@ -713,8 +713,9 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
                     selections[vecOffset + resNum].node = results[resOffset + resNum].idx;
                     selections[vecOffset + resNum].distance = (float)results[resOffset + resNum].dist;
                 }
-                resIdx++;
+//                resIdx++;
             }
+                resIdx++;
         }
         delete[] results;
     }

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -650,16 +650,15 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
 
     if(GetVectorValueType() != VectorValueType::Float) {
         typedef int32_t SUMTYPE;
-        DistPair<SUMTYPE>* results = new DistPair<SUMTYPE>[((size_t)fullVectors->Count())*((size_t)replicaCount)];
 
         switch (GetVectorValueType())
         {
 #define DefineVectorValueType(Name, Type) \
         case VectorValueType::Name: \
             if(fullVectors->Dimension() <= 64) { \
-                getTailNeighborsTPT<Type, float, SUMTYPE, 64>((Type*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 64, (DistPair<SUMTYPE>*)results, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs); \
+                getTailNeighborsTPT<Type, float, SUMTYPE, 64>((Type*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 64, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs, selections); \
             } else if (fullVectors->Dimension() <= 100) { \
-                getTailNeighborsTPT<Type, float, SUMTYPE, 100>((Type*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 100, (DistPair<SUMTYPE>*)results, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs); \
+                getTailNeighborsTPT<Type, float, SUMTYPE, 100>((Type*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 100, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs, selections); \
             } else { \
                 LOG(Helper::LogLevel::LL_Error, "Datasets of >100 dimensions not currently supported for GPU Index build\n"); \
                 exit(1); \
@@ -671,53 +670,20 @@ void VectorIndex::ApproximateRNG(std::shared_ptr<VectorSet>& fullVectors, std::u
 
         default: break;
         }
-
-        SizeType resIdx = 0;
-        //#pragma omp parallel for
-        for (SizeType vecIdx = 0; vecIdx < fullVectors->Count(); vecIdx++) {
-            if (exceptIDS.count(vecIdx) == 0) {
-                size_t vecOffset = vecIdx * (size_t)replicaCount;
-                size_t resOffset = resIdx * (size_t)replicaCount;
-                for (int resNum = 0; resNum < replicaCount && results[resOffset + resNum].idx != -1; resNum++) {
-                    selections[vecOffset + resNum].node = results[resOffset + resNum].idx;
-                    selections[vecOffset + resNum].distance = (float)results[resOffset + resNum].dist;
-                }
-//                resIdx++;
-            }
-            resIdx++;
-        }
-        delete[] results;
     }
     else {
         typedef float SUMTYPE;
-        DistPair<SUMTYPE>* results = new DistPair<SUMTYPE>[((size_t)fullVectors->Count())*((size_t)replicaCount)];
 
         if (fullVectors->Dimension() <= 64) {
-            getTailNeighborsTPT<float, float, SUMTYPE, 64>((float*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 64, (DistPair<SUMTYPE>*)results, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs);
+            getTailNeighborsTPT<float, float, SUMTYPE, 64>((float*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 64, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs, selections);
         }
         else if (fullVectors->Dimension() <= 100) {
-            getTailNeighborsTPT<float, float, SUMTYPE, 100>((float*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 100, (DistPair<SUMTYPE>*)results, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs);
+            getTailNeighborsTPT<float, float, SUMTYPE, 100>((float*)fullVectors->GetData(), fullVectors->Count(), this, exceptIDS, 100, replicaCount, numThreads, numTrees, leafSize, metric, numGPUs, selections);
         }
         else {
             LOG(Helper::LogLevel::LL_Error, "Datasets of >100 dimensions not currently supported for GPU Index build\n");
             exit(1);
         }
-
-        SizeType resIdx = 0;
-        //#pragma omp parallel for
-        for (SizeType vecIdx = 0; vecIdx < fullVectors->Count(); vecIdx++) {
-            if (exceptIDS.count(vecIdx) == 0) {
-                size_t vecOffset = vecIdx * (size_t)replicaCount;
-                size_t resOffset = resIdx * (size_t)replicaCount;
-                for (int resNum = 0; resNum < replicaCount && results[resOffset + resNum].idx != -1; resNum++) {
-                    selections[vecOffset + resNum].node = results[resOffset + resNum].idx;
-                    selections[vecOffset + resNum].distance = (float)results[resOffset + resNum].dist;
-                }
-//                resIdx++;
-            }
-                resIdx++;
-        }
-        delete[] results;
     }
 }
 #else


### PR DESCRIPTION
Reduces the amount of CPU memory allocated by the GPU code.  This is accomplished by converting and shuttling data onto the GPU in small batches, removing the need for copies of the entire dataset.  Using this method, the copies of the input vector list (head vectors and tail vecotrs) and the result list are avoided.