### PR TITLE
Prevent build from failing on pre-_MSC_VER 1920 compilers

### DIFF
--- a/AnnService/src/Core/Common/DistanceUtils.cpp
+++ b/AnnService/src/Core/Common/DistanceUtils.cpp
@@ -193,6 +193,8 @@ inline __m256 _mm256_sqdf_ps(__m256 X, __m256 Y)
     return _mm256_mul_ps(d, d);
 }
 
+// Do not use intrinsics not supported by old MS compiler version
+#if (!defined _MSC_VER) || (_MSC_VER >= 1920)
 inline __m512 _mm512_mul_epi8(__m512i X, __m512i Y)
 {
     __m512i zero = _mm512_setzero_si512();
@@ -290,6 +292,7 @@ inline __m512 _mm512_sqdf_ps(__m512 X, __m512 Y)
     __m512 d = _mm512_sub_ps(X, Y);
     return _mm512_mul_ps(d, d);
 }
+#endif
 
 
 #define REPEAT(type, ctype, delta, load, exec, acc, result) \
@@ -360,6 +363,9 @@ float DistanceUtils::ComputeL2Distance_AVX(const std::int8_t* pX, const std::int
 
 float DistanceUtils::ComputeL2Distance_AVX512(const std::int8_t* pX, const std::int8_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::int8_t* pEnd64 = pX + ((length >> 6) << 6);
     const std::int8_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::int8_t* pEnd16 = pX + ((length >> 4) << 4);
@@ -390,6 +396,7 @@ float DistanceUtils::ComputeL2Distance_AVX512(const std::int8_t* pX, const std::
         float c1 = ((float)(*pX++) - (float)(*pY++)); diff += c1 * c1;
     }
     return diff;
+#endif
 }
 
 float DistanceUtils::ComputeL2Distance_SSE(const std::uint8_t* pX, const std::uint8_t* pY, DimensionType length)
@@ -452,6 +459,9 @@ float DistanceUtils::ComputeL2Distance_AVX(const std::uint8_t* pX, const std::ui
 
 float DistanceUtils::ComputeL2Distance_AVX512(const std::uint8_t* pX, const std::uint8_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::uint8_t* pEnd64 = pX + ((length >> 6) << 6);
     const std::uint8_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::uint8_t* pEnd16 = pX + ((length >> 4) << 4);
@@ -482,6 +492,7 @@ float DistanceUtils::ComputeL2Distance_AVX512(const std::uint8_t* pX, const std:
         float c1 = ((float)(*pX++) - (float)(*pY++)); diff += c1 * c1;
     }
     return diff;
+#endif
 }
 
 float DistanceUtils::ComputeL2Distance_SSE(const std::int16_t* pX, const std::int16_t* pY, DimensionType length)
@@ -546,6 +557,9 @@ float DistanceUtils::ComputeL2Distance_AVX(const std::int16_t* pX, const std::in
 
 float DistanceUtils::ComputeL2Distance_AVX512(const std::int16_t* pX, const std::int16_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::int16_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::int16_t* pEnd16 = pX + ((length >> 4) << 4);
     const std::int16_t* pEnd8 = pX + ((length >> 3) << 3);
@@ -577,6 +591,7 @@ float DistanceUtils::ComputeL2Distance_AVX512(const std::int16_t* pX, const std:
         float c1 = ((float)(*pX++) - (float)(*pY++)); diff += c1 * c1;
     }
     return diff;
+#endif
 }
 
 float DistanceUtils::ComputeL2Distance_SSE(const float* pX, const float* pY, DimensionType length)
@@ -632,6 +647,9 @@ float DistanceUtils::ComputeL2Distance_AVX(const float* pX, const float* pY, Dim
 
 float DistanceUtils::ComputeL2Distance_AVX512(const float* pX, const float* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const float* pEnd16 = pX + ((length >> 4) << 4);
     const float* pEnd4 = pX + ((length >> 2) << 2);
     const float* pEnd1 = pX + length;
@@ -653,6 +671,7 @@ float DistanceUtils::ComputeL2Distance_AVX512(const float* pX, const float* pY, 
         float c1 = (*pX++) - (*pY++); diff += c1 * c1;
     }
     return diff;
+#endif
 }
 
 float DistanceUtils::ComputeCosineDistance_SSE(const std::int8_t* pX, const std::int8_t* pY, DimensionType length)
@@ -713,6 +732,9 @@ float DistanceUtils::ComputeCosineDistance_AVX(const std::int8_t* pX, const std:
 
 float DistanceUtils::ComputeCosineDistance_AVX512(const std::int8_t* pX, const std::int8_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::int8_t* pEnd64 = pX + ((length >> 6) << 6);
     const std::int8_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::int8_t* pEnd16 = pX + ((length >> 4) << 4);
@@ -742,6 +764,7 @@ float DistanceUtils::ComputeCosineDistance_AVX512(const std::int8_t* pX, const s
     }
     while (pX < pEnd1) diff += ((float)(*pX++) * (float)(*pY++));
     return 16129 - diff;
+#endif
 }
 
 float DistanceUtils::ComputeCosineDistance_SSE(const std::uint8_t* pX, const std::uint8_t* pY, DimensionType length)
@@ -802,6 +825,9 @@ float DistanceUtils::ComputeCosineDistance_AVX(const std::uint8_t* pX, const std
 
 float DistanceUtils::ComputeCosineDistance_AVX512(const std::uint8_t* pX, const std::uint8_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::uint8_t* pEnd64 = pX + ((length >> 6) << 6);
     const std::uint8_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::uint8_t* pEnd16 = pX + ((length >> 4) << 4);
@@ -831,6 +857,7 @@ float DistanceUtils::ComputeCosineDistance_AVX512(const std::uint8_t* pX, const 
     }
     while (pX < pEnd1) diff += ((float)(*pX++) * (float)(*pY++));
     return 65025 - diff;
+#endif
 }
 
 float DistanceUtils::ComputeCosineDistance_SSE(const std::int16_t* pX, const std::int16_t* pY, DimensionType length)
@@ -893,6 +920,9 @@ float DistanceUtils::ComputeCosineDistance_AVX(const std::int16_t* pX, const std
 
 float DistanceUtils::ComputeCosineDistance_AVX512(const std::int16_t* pX, const std::int16_t* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const std::int16_t* pEnd32 = pX + ((length >> 5) << 5);
     const std::int16_t* pEnd16 = pX + ((length >> 4) << 4);
     const std::int16_t* pEnd8 = pX + ((length >> 3) << 3);
@@ -923,6 +953,7 @@ float DistanceUtils::ComputeCosineDistance_AVX512(const std::int16_t* pX, const 
 
     while (pX < pEnd1) diff += ((float)(*pX++) * (float)(*pY++));
     return  1073676289 - diff;
+#endif
 }
 
 float DistanceUtils::ComputeCosineDistance_SSE(const float* pX, const float* pY, DimensionType length)
@@ -974,6 +1005,9 @@ float DistanceUtils::ComputeCosineDistance_AVX(const float* pX, const float* pY,
 
 float DistanceUtils::ComputeCosineDistance_AVX512(const float* pX, const float* pY, DimensionType length)
 {
+#if (defined _MSC_VER) && (_MSC_VER < 1920)
+    throw std::exception("AVX-512 not supported");
+#else
     const float* pEnd16 = pX + ((length >> 4) << 4);
     const float* pEnd4 = pX + ((length >> 2) << 2);
     const float* pEnd1 = pX + length;
@@ -993,4 +1027,5 @@ float DistanceUtils::ComputeCosineDistance_AVX512(const float* pX, const float* 
 
     while (pX < pEnd1) diff += (*pX++) * (*pY++);
     return 1 - diff;
+#endif
 }

--- a/AnnService/src/Core/Common/InstructionUtils.cpp
+++ b/AnnService/src/Core/Common/InstructionUtils.cpp
@@ -56,6 +56,13 @@ namespace SPTAG {
                 cpuid(info, 0x00000007);
                 HW_AVX2 = (info[1] & ((int)1 << 5)) != 0;
                 HW_AVX512 = (info[1] & (((int)1 << 16) | ((int) 1 << 30)));
+
+// If we are not compiling support for AVX-512 due to old compiler version, we should not call it
+#ifdef _MSC_VER
+#if _MSC_VER < 1920
+                HW_AVX512 = false;
+#endif
+#endif
             }
             if (HW_AVX512)
                 LOG(Helper::LogLevel::LL_Info, "Using AVX512 InstructionSet!\n");

--- a/SPTAG.nuspec
+++ b/SPTAG.nuspec
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>SPTAG.Library</id>
+    <version>1.2.12-mainOPQ-CoreLib-SPANN-c6a30481-vc140</version>
+    <title>SPTAG.Library</title>
+    <authors>cheqi,haidwa,mingqli</authors>
+    <owners>cheqi,haidwa,mingqli,zhah</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/microsoft/SPTAG</licenseUrl>
+    <projectUrl>https://github.com/microsoft/SPTAG</projectUrl>
+    <description>SPTAG (Space Partition Tree And Graph) is a library for large scale vector approximate nearest neighbor search scenario released by Microsoft Research (MSR) and Microsoft Bing.</description>
+    <releaseNotes>publish with commit microsoft/legacy-avx512/c6a30481</releaseNotes>
+    <copyright>Copyright © Microsoft</copyright>
+  </metadata>
+  <files>
+    <file src="AnnService\inc\Core\BKT\Index.h" target="build\native\inc\Core\BKT\Index.h" />
+    <file src="AnnService\inc\Core\BKT\ParameterDefinitionList.h" target="build\native\inc\Core\BKT\ParameterDefinitionList.h" />
+    <file src="AnnService\inc\Core\Common\cuda\Distance.hxx" target="build\native\inc\Core\Common\cuda\Distance.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\Kmeans.hxx" target="build\native\inc\Core\Common\cuda\Kmeans.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\KNN.hxx" target="build\native\inc\Core\Common\cuda\KNN.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\params.h" target="build\native\inc\Core\Common\cuda\params.h" />
+    <file src="AnnService\inc\Core\Common\cuda\Refine.hxx" target="build\native\inc\Core\Common\cuda\Refine.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\TailNeighbors.hxx" target="build\native\inc\Core\Common\cuda\TailNeighbors.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\ThreadHeap.hxx" target="build\native\inc\Core\Common\cuda\ThreadHeap.hxx" />
+    <file src="AnnService\inc\Core\Common\cuda\TPtree.hxx" target="build\native\inc\Core\Common\cuda\TPtree.hxx" />
+    <file src="AnnService\inc\Core\Common\BKTree.h" target="build\native\inc\Core\Common\BKTree.h" />
+    <file src="AnnService\inc\Core\Common\CommonUtils.h" target="build\native\inc\Core\Common\CommonUtils.h" />
+    <file src="AnnService\inc\Core\Common\Dataset.h" target="build\native\inc\Core\Common\Dataset.h" />
+    <file src="AnnService\inc\Core\Common\DistanceUtils.h" target="build\native\inc\Core\Common\DistanceUtils.h" />
+    <file src="AnnService\inc\Core\Common\FineGrainedLock.h" target="build\native\inc\Core\Common\FineGrainedLock.h" />
+    <file src="AnnService\inc\Core\Common\Heap.h" target="build\native\inc\Core\Common\Heap.h" />
+    <file src="AnnService\inc\Core\Common\InstructionUtils.h" target="build\native\inc\Core\Common\InstructionUtils.h" />
+    <file src="AnnService\inc\Core\Common\IQuantizer.h" target="build\native\inc\Core\Common\IQuantizer.h" />
+    <file src="AnnService\inc\Core\Common\KDTree.h" target="build\native\inc\Core\Common\KDTree.h" />
+    <file src="AnnService\inc\Core\Common\KNearestNeighborhoodGraph.h" target="build\native\inc\Core\Common\KNearestNeighborhoodGraph.h" />
+    <file src="AnnService\inc\Core\Common\Labelset.h" target="build\native\inc\Core\Common\Labelset.h" />
+    <file src="AnnService\inc\Core\Common\NeighborhoodGraph.h" target="build\native\inc\Core\Common\NeighborhoodGraph.h" />
+    <file src="AnnService\inc\Core\Common\OPQQuantizer.h" target="build\native\inc\Core\Common\OPQQuantizer.h" />
+    <file src="AnnService\inc\Core\Common\PQQuantizer.h" target="build\native\inc\Core\Common\PQQuantizer.h" />
+    <file src="AnnService\inc\Core\Common\QueryResultSet.h" target="build\native\inc\Core\Common\QueryResultSet.h" />
+    <file src="AnnService\inc\Core\Common\RelativeNeighborhoodGraph.h" target="build\native\inc\Core\Common\RelativeNeighborhoodGraph.h" />
+    <file src="AnnService\inc\Core\Common\TruthSet.h" target="build\native\inc\Core\Common\TruthSet.h" />
+    <file src="AnnService\inc\Core\Common\WorkSpace.h" target="build\native\inc\Core\Common\WorkSpace.h" />
+    <file src="AnnService\inc\Core\Common\WorkSpacePool.h" target="build\native\inc\Core\Common\WorkSpacePool.h" />
+    <file src="AnnService\inc\Core\KDT\Index.h" target="build\native\inc\Core\KDT\Index.h" />
+    <file src="AnnService\inc\Core\KDT\ParameterDefinitionList.h" target="build\native\inc\Core\KDT\ParameterDefinitionList.h" />
+    <file src="AnnService\inc\Core\SPANN\ExtraFullGraphSearcher.h" target="build\native\inc\Core\SPANN\ExtraFullGraphSearcher.h" />
+    <file src="AnnService\inc\Core\SPANN\IExtraSearcher.h" target="build\native\inc\Core\SPANN\IExtraSearcher.h" />
+    <file src="AnnService\inc\Core\SPANN\Index.h" target="build\native\inc\Core\SPANN\Index.h" />
+    <file src="AnnService\inc\Core\SPANN\Options.h" target="build\native\inc\Core\SPANN\Options.h" />
+    <file src="AnnService\inc\Core\SPANN\ParameterDefinitionList.h" target="build\native\inc\Core\SPANN\ParameterDefinitionList.h" />
+    <file src="AnnService\inc\Core\Common.h" target="build\native\inc\Core\Common.h" />
+    <file src="AnnService\inc\Core\CommonDataStructure.h" target="build\native\inc\Core\CommonDataStructure.h" />
+    <file src="AnnService\inc\Core\DefinitionList.h" target="build\native\inc\Core\DefinitionList.h" />
+    <file src="AnnService\inc\Core\MetadataSet.h" target="build\native\inc\Core\MetadataSet.h" />
+    <file src="AnnService\inc\Core\SearchQuery.h" target="build\native\inc\Core\SearchQuery.h" />
+    <file src="AnnService\inc\Core\SearchResult.h" target="build\native\inc\Core\SearchResult.h" />
+    <file src="AnnService\inc\Core\VectorIndex.h" target="build\native\inc\Core\VectorIndex.h" />
+    <file src="AnnService\inc\Core\VectorSet.h" target="build\native\inc\Core\VectorSet.h" />
+    <file src="AnnService\inc\Helper\VectorSetReaders\DefaultReader.h" target="build\native\inc\Helper\VectorSetReaders\DefaultReader.h" />
+    <file src="AnnService\inc\Helper\VectorSetReaders\MemoryReader.h" target="build\native\inc\Helper\VectorSetReaders\MemoryReader.h" />
+    <file src="AnnService\inc\Helper\VectorSetReaders\TxtReader.h" target="build\native\inc\Helper\VectorSetReaders\TxtReader.h" />
+    <file src="AnnService\inc\Helper\VectorSetReaders\XvecReader.h" target="build\native\inc\Helper\VectorSetReaders\XvecReader.h" />
+    <file src="AnnService\inc\Helper\ArgumentsParser.h" target="build\native\inc\Helper\ArgumentsParser.h" />
+    <file src="AnnService\inc\Helper\AsyncFileReader.h" target="build\native\inc\Helper\AsyncFileReader.h" />
+    <file src="AnnService\inc\Helper\Base64Encode.h" target="build\native\inc\Helper\Base64Encode.h" />
+    <file src="AnnService\inc\Helper\CommonHelper.h" target="build\native\inc\Helper\CommonHelper.h" />
+    <file src="AnnService\inc\Helper\Concurrent.h" target="build\native\inc\Helper\Concurrent.h" />
+    <file src="AnnService\inc\Helper\ConcurrentSet.h" target="build\native\inc\Helper\ConcurrentSet.h" />
+    <file src="AnnService\inc\Helper\DiskIO.h" target="build\native\inc\Helper\DiskIO.h" />
+    <file src="AnnService\inc\Helper\DynamicNeighbors.h" target="build\native\inc\Helper\DynamicNeighbors.h" />
+    <file src="AnnService\inc\Helper\LockFree.h" target="build\native\inc\Helper\LockFree.h" />
+    <file src="AnnService\inc\Helper\Logging.h" target="build\native\inc\Helper\Logging.h" />
+    <file src="AnnService\inc\Helper\SimpleIniReader.h" target="build\native\inc\Helper\SimpleIniReader.h" />
+    <file src="AnnService\inc\Helper\StringConvert.h" target="build\native\inc\Helper\StringConvert.h" />
+    <file src="AnnService\inc\Helper\ThreadPool.h" target="build\native\inc\Helper\ThreadPool.h" />
+    <file src="AnnService\inc\Helper\VectorSetReader.h" target="build\native\inc\Helper\VectorSetReader.h" />
+    <file src="x64\Debug\CoreLibrary.lib" target="lib\native\debug\x64\CoreLibrary.lib" />
+    <file src="x64\Debug\CoreLibrary.pdb" target="lib\native\debug\x64\CoreLibrary.pdb" />
+    <file src="x64\Release\CoreLibrary.lib" target="lib\native\retail\x64\CoreLibrary.lib" />
+    <file src="obj\x64_Release\CoreLibrary\CoreLibrary.pdb" target="lib\native\retail\x64\CoreLibrary.pdb" />
+  </files>
+</package>


### PR DESCRIPTION
AVX-512 intrinsics are not supported on some compilers we use. It also adds a nuspec file for easily building new versions of Nuget-packaged corelibrary