### PR TITLE
Avoid offset WriteBinary call in SaveIndexToFile

### DIFF
--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -365,7 +365,7 @@ VectorIndex::SaveIndexToFile(const std::string& p_file, IAbortOperation* p_abort
     if (fp == nullptr || !fp->Initialize(p_file.c_str(), std::ios::binary | std::ios::out)) return ErrorCode::FailedCreateFile;
 
     auto mp = std::shared_ptr<Helper::DiskIO>(new Helper::SimpleBufferIO());
-    if (mp == nullptr || !mp->Initialize(p_file.c_str(), std::ios::binary | std::ios::out)) return ErrorCode::FailedCreateFile;
+    if (mp == nullptr || !mp->Initialize(nullptr, std::ios::binary | std::ios::out)) return ErrorCode::FailedCreateFile;
     ErrorCode ret = ErrorCode::Success;
     if ((ret = SaveIndexConfig(mp)) != ErrorCode::Success) return ret;
 

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -364,12 +364,16 @@ VectorIndex::SaveIndexToFile(const std::string& p_file, IAbortOperation* p_abort
     auto fp = SPTAG::f_createIO();
     if (fp == nullptr || !fp->Initialize(p_file.c_str(), std::ios::binary | std::ios::out)) return ErrorCode::FailedCreateFile;
 
+    auto mp = std::shared_ptr<Helper::DiskIO>(new Helper::SimpleBufferIO());
+    if (mp == nullptr || !mp->Initialize(p_file.c_str(), std::ios::binary | std::ios::out)) return ErrorCode::FailedCreateFile;
     ErrorCode ret = ErrorCode::Success;
-    
-    std::uint64_t configSize = 0;
+    if ((ret = SaveIndexConfig(mp)) != ErrorCode::Success) return ret;
+
+    std::uint64_t configSize = mp->TellP();
+    mp->ShutDown();
+
     IOBINARY(fp, WriteBinary, sizeof(configSize), (char*)&configSize);
     if ((ret = SaveIndexConfig(fp)) != ErrorCode::Success) return ret;
-    configSize = fp->TellP() - sizeof(configSize);
 
     if (p_abort != nullptr && p_abort->ShouldAbort()) ret = ErrorCode::ExternalAbort;
     else {
@@ -393,7 +397,6 @@ VectorIndex::SaveIndexToFile(const std::string& p_file, IAbortOperation* p_abort
             ret = m_pQuantizer->SaveQuantizer(fp);
         }
     }
-    if (ErrorCode::Success == ret) IOBINARY(fp, WriteBinary, sizeof(configSize), (char*)&configSize, 0);
     fp->ShutDown();
 
     if (ret != ErrorCode::Success) std::remove(p_file.c_str());


### PR DESCRIPTION
Use SimpleBufferedIO to calculate the config file size instead of going back after writing it