### PR TITLE
Fix low accuracy issue with GPU index build for int8/cosine configuration

### DIFF
--- a/AnnService/inc/Core/Common/cuda/KNN.hxx
+++ b/AnnService/inc/Core/Common/cuda/KNN.hxx
@@ -273,10 +273,11 @@ __global__ void findRNG_selector(PointSet<T>* ps, TPtree* tptree, int KVAL, int*
 
   extern __shared__ char sharememory[];
 
+// Enable dimension of dataset that you will be using for maximum performance
   if(quantizer == NULL) {
-//    RUN_KERNEL(64);
+    RUN_KERNEL(64);
     RUN_KERNEL(100);
-    RUN_KERNEL(200);
+//    RUN_KERNEL(200);
 //    RUN_KERNEL(MAX_SHAPE);
   }
   else {
@@ -367,7 +368,6 @@ void buildGraphGPU(SPTAG::VectorIndex* index, size_t dataSize, int KVAL, int tre
   GPU_PQQuantizer* h_quantizer = NULL; 
 
   if(use_q) {
-printf("Using quantizer, and metric:%d (L2?:%d)\n", (metric), (DistMetric)metric == DistMetric::L2);
     h_quantizer = new GPU_PQQuantizer(index->m_pQuantizer, (DistMetric)metric);
     CUDA_CHECK(cudaMalloc(&d_quantizer, sizeof(GPU_PQQuantizer)));
     CUDA_CHECK(cudaMemcpy(d_quantizer, h_quantizer, sizeof(GPU_PQQuantizer), cudaMemcpyHostToDevice));

--- a/AnnService/inc/Core/Common/cuda/TPtree.hxx
+++ b/AnnService/inc/Core/Common/cuda/TPtree.hxx
@@ -250,7 +250,8 @@ __host__ void construct_trees_multigpu(TPtree** d_trees, PointSet<T>** ps, int N
             find_level_sum<T><<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(ps[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->Dim, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, nodes_on_level, i);
         }
 
-/* TODO - fix rebalancing
+// TODO - fix rebalancing
+/*
         // Check and rebalance all levels beyond the first (first level has only 1 node)
         if(i > 0) {
             for(int gpuNum=0; gpuNum < NUM_GPUS; ++gpuNum) {
@@ -272,6 +273,7 @@ __host__ void construct_trees_multigpu(TPtree** d_trees, PointSet<T>** ps, int N
 
             update_node_assignments<T><<<RUN_BLOCKS,THREADS,0,streams[gpuNum]>>>(ps[gpuNum], d_trees[gpuNum]->weight_list, d_trees[gpuNum]->node_ids, d_trees[gpuNum]->split_keys, d_trees[gpuNum]->node_sizes, N, i, d_trees[gpuNum]->Dim);
         }
+
         nodes_on_level*=2;
 
     }
@@ -407,9 +409,9 @@ template<typename T>
 __global__ void find_level_sum(PointSet<T>* ps, KEYTYPE* weights, int Dim, int* node_ids, KEYTYPE* split_keys, int* node_sizes, int N, int nodes_on_level, int level) {
   KEYTYPE val=0;
   int size = min(N, nodes_on_level*SAMPLES);
-  int step = N/size;
   for(int i=blockIdx.x*blockDim.x+threadIdx.x; i<size; i+=blockDim.x*gridDim.x) {
     val = weighted_val<T>(ps->getVec(i), &weights[level*Dim], Dim);
+
     atomicAdd(&split_keys[node_ids[i]], val);
     atomicAdd(&node_sizes[node_ids[i]], 1);
   }

--- a/AnnService/src/SSDServing/main.cpp
+++ b/AnnService/src/SSDServing/main.cpp
@@ -177,7 +177,7 @@ namespace SPTAG {
 	}
 }
 
-// switch between exe and static library by _$(OutputType)
+// switch between exe and static library by _$(OutputType) 
 #ifdef _exe
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Fix for issue where GPU index build with int8 datatype and cosine distance metric resulting in low accuracy.  This is due to the base being incorrectly computed for int8.  Also enabled the hardware optimization for this case, which provides a ~60% perf gain over the standard cosine distance function.