### PR TITLE
fix bkt bug: shuffle bug when clustering

### DIFF
--- a/AnnService/inc/Core/Common/BKTree.h
+++ b/AnnService/inc/Core/Common/BKTree.h
@@ -112,7 +112,7 @@ namespace SPTAG
                 for (int k = 1; k < _K; k++) pos[k] = pos[k - 1] + newCounts[k - 1];
 
                 for (int k = 0; k < _K; k++) {
-                    if (newCounts[k] == 0) continue;
+                    // if (newCounts[k] == 0) continue;
                     SizeType i = pos[k];
                     while (newCounts[k] > 0) {
                         SizeType swapid = pos[label[i]] + newCounts[label[i]] - 1;


### PR DESCRIPTION
In some situation, shuffle will not make sure that indice[pos[k] + counts[k] -1] == clusterIdx[k]:
assume there are 100 vectors and we cluster them into 2 clusters with size 70 and 30, and it just so happens that clusters containing 30 vectors are all in indices[0~69], shuffle functions will not swap clusterIdx of the second cluster since newCounts[1] is being zero in the first loop.