### PR TITLE
Fix static initialization fiasco problem with the logger and code calling into it from other TUs

### DIFF
--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -124,8 +124,9 @@ extern std::shared_ptr<Helper::DiskIO>(*f_createIO)();
 #define IOSTRING(ptr, func, ...) if (ptr->func(__VA_ARGS__) == 0) return ErrorCode::DiskIOFail
 
 extern std::shared_ptr<Helper::Logger> g_pLogger;
+extern std::shared_ptr<Helper::Logger> GetLogger();
 
-#define LOG(l, ...) g_pLogger->Logging("SPTAG", l, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define LOG(l, ...) GetLogger()->Logging("SPTAG", l, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 
 class MyException : public std::exception 
 {

--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -123,7 +123,6 @@ extern std::shared_ptr<Helper::DiskIO>(*f_createIO)();
 #define IOBINARY(ptr, func, bytes, ...) if (ptr->func(bytes, __VA_ARGS__) != bytes) return ErrorCode::DiskIOFail
 #define IOSTRING(ptr, func, ...) if (ptr->func(__VA_ARGS__) == 0) return ErrorCode::DiskIOFail
 
-extern std::shared_ptr<Helper::Logger> g_pLogger;
 extern std::shared_ptr<Helper::Logger> GetLogger();
 
 #define LOG(l, ...) GetLogger()->Logging("SPTAG", l, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)

--- a/AnnService/inc/SSDServing/SSDIndex.h
+++ b/AnnService/inc/SSDServing/SSDIndex.h
@@ -174,7 +174,7 @@ namespace SPTAG {
 
                 if (!p_opts.m_logFile.empty())
                 {
-                    g_pLogger.reset(new Helper::FileLogger(Helper::LogLevel::LL_Info, p_opts.m_logFile.c_str()));
+                    GetLogger().reset(new Helper::FileLogger(Helper::LogLevel::LL_Info, p_opts.m_logFile.c_str()));
                 }
                 int numThreads = p_opts.m_iSSDNumberOfThreads;
                 int internalResultNum = p_opts.m_searchInternalResultNum;

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -15,12 +15,17 @@ typedef typename SPTAG::Helper::Concurrent::ConcurrentMap<std::string, SPTAG::Si
 
 using namespace SPTAG;
 
+std::shared_ptr<Helper::Logger> SPTAG::g_pLogger;
+std::shared_ptr<Helper::Logger> GetLogger() {
+  if (SPTAG::g_pLogger == nullptr) {
 #ifdef DEBUG
-std::shared_ptr<Helper::Logger> SPTAG::g_pLogger(new Helper::SimpleLogger(Helper::LogLevel::LL_Debug));
+    SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Debug));
 #else
-std::shared_ptr<Helper::Logger> SPTAG::g_pLogger(new Helper::SimpleLogger(Helper::LogLevel::LL_Info));
+    SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Info));
 #endif
-
+  }
+  return SPTAG::g_pLogger;
+}
 std::mt19937 SPTAG::rg;
 
 std::shared_ptr<Helper::DiskIO>(*SPTAG::f_createIO)() = []() -> std::shared_ptr<Helper::DiskIO> { return std::shared_ptr<Helper::DiskIO>(new Helper::SimpleFileIO()); };

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -16,7 +16,7 @@ typedef typename SPTAG::Helper::Concurrent::ConcurrentMap<std::string, SPTAG::Si
 using namespace SPTAG;
 
 std::shared_ptr<Helper::Logger> SPTAG::g_pLogger;
-std::shared_ptr<Helper::Logger> GetLogger() {
+std::shared_ptr<Helper::Logger> SPTAG::GetLogger() {
   if (SPTAG::g_pLogger == nullptr) {
 #ifdef DEBUG
     SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Debug));

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -17,10 +17,16 @@ using namespace SPTAG;
 
 std::shared_ptr<Helper::Logger> SPTAG::GetLogger() {
 #ifdef DEBUG
-  constexpr auto logLevel = Helper::LogLevel::LL_Debug;
+  auto logLevel = Helper::LogLevel::LL_Debug;
 #else
-  constexpr auto logLevel = Helper::LogLevel::LL_Info;
+  auto logLevel = Helper::LogLevel::LL_Info;
 #endif
+  if (auto exeHandle = GetModuleHandleW(nullptr)) {
+    if (auto SPTAG_GetLoggerLevel = reinterpret_cast<SPTAG::Helper::LogLevel(*)()>(GetProcAddress(exeHandle, "SPTAG_GetLoggerLevel"))) {
+      logLevel = SPTAG_GetLoggerLevel();
+    }
+  }
+
   static std::shared_ptr<Helper::Logger> s_pLogger = std::make_shared<Helper::SimpleLogger>(logLevel);
   return s_pLogger;
 }

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -15,18 +15,16 @@ typedef typename SPTAG::Helper::Concurrent::ConcurrentMap<std::string, SPTAG::Si
 
 using namespace SPTAG;
 
-std::shared_ptr<Helper::Logger> SPTAG::g_pLogger;
-std::once_flag g_initLogger;
 std::shared_ptr<Helper::Logger> SPTAG::GetLogger() {
-  std::call_once(g_initLogger, []() {
 #ifdef DEBUG
-    SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Debug));
+  constexpr auto logLevel = Helper::LogLevel::LL_Debug;
 #else
-    SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Info));
+  constexpr auto logLevel = Helper::LogLevel::LL_Info;
 #endif
-    });
-  return SPTAG::g_pLogger;
+  static std::shared_ptr<Helper::Logger> s_pLogger = std::make_shared<Helper::SimpleLogger>(logLevel);
+  return s_pLogger;
 }
+
 std::mt19937 SPTAG::rg;
 
 std::shared_ptr<Helper::DiskIO>(*SPTAG::f_createIO)() = []() -> std::shared_ptr<Helper::DiskIO> { return std::shared_ptr<Helper::DiskIO>(new Helper::SimpleFileIO()); };

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -16,14 +16,15 @@ typedef typename SPTAG::Helper::Concurrent::ConcurrentMap<std::string, SPTAG::Si
 using namespace SPTAG;
 
 std::shared_ptr<Helper::Logger> SPTAG::g_pLogger;
+std::once_flag g_initLogger;
 std::shared_ptr<Helper::Logger> SPTAG::GetLogger() {
-  if (SPTAG::g_pLogger == nullptr) {
+  std::call_once(g_initLogger, []() {
 #ifdef DEBUG
     SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Debug));
 #else
     SPTAG::g_pLogger.reset(new Helper::SimpleLogger(Helper::LogLevel::LL_Info));
 #endif
-  }
+    });
   return SPTAG::g_pLogger;
 }
 std::mt19937 SPTAG::rg;

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -21,11 +21,13 @@ std::shared_ptr<Helper::Logger> SPTAG::GetLogger() {
 #else
   auto logLevel = Helper::LogLevel::LL_Info;
 #endif
+#ifdef  _WINDOWS_
   if (auto exeHandle = GetModuleHandleW(nullptr)) {
     if (auto SPTAG_GetLoggerLevel = reinterpret_cast<SPTAG::Helper::LogLevel(*)()>(GetProcAddress(exeHandle, "SPTAG_GetLoggerLevel"))) {
       logLevel = SPTAG_GetLoggerLevel();
     }
   }
+#endif //  _WINDOWS_
 
   static std::shared_ptr<Helper::Logger> s_pLogger = std::make_shared<Helper::SimpleLogger>(logLevel);
   return s_pLogger;

--- a/AnnService/src/Quantizer/main.cpp
+++ b/AnnService/src/Quantizer/main.cpp
@@ -68,7 +68,7 @@ void QuantizeAndSave(std::shared_ptr<SPTAG::Helper::VectorSetReader>& vectorRead
 
 int main(int argc, char* argv[])
 {
-    std::shared_ptr<QuantizerOptions> options = std::make_shared<QuantizerOptions>(10000, true, 0.0, SPTAG::QuantizerType::None, std::string(), -1, std::string(), std::string());
+    std::shared_ptr<QuantizerOptions> options = std::make_shared<QuantizerOptions>(10000, true, 0.0f, SPTAG::QuantizerType::None, std::string(), -1, std::string(), std::string());
 
     if (!options->Parse(argc - 1, argv + 1))
     {

--- a/AnnService/src/Server/SearchService.cpp
+++ b/AnnService/src/Server/SearchService.cpp
@@ -84,7 +84,7 @@ SearchService::Initialize(int p_argNum, char* p_args[])
     }
 
     if (!cmdOptions.m_logFile.empty()) {
-        g_pLogger.reset(new Helper::FileLogger(Helper::LogLevel::LL_Debug, cmdOptions.m_logFile.c_str()));
+        GetLogger().reset(new Helper::FileLogger(Helper::LogLevel::LL_Debug, cmdOptions.m_logFile.c_str()));
     }
 
     m_serviceContext.reset(new ServiceContext(cmdOptions.m_configFile));


### PR DESCRIPTION
There is currently a dependency between the order of dynamic initializers for the logger and things that call into it, like CpuREP (see #356 for a related issue). This can result in crashes because the order of dynamic initializers across translation units is not deterministic in C++.

The fix is to access the logger via a function call that allows us to defer the logger initialization until it is needed (in a thread-safe manner). Using "magic statics" to do that.

An app will now be able to customize the log level (to suppress logging from dynamic initializers) by exporting a function with a certain name, which we will look up during `GetLogger()`:

App code:
```cpp
extern "C" __declspec(dllexport) LogLevel SPTAG_GetLoggerLevel() 
{ 
    return LogLevel::Empty;
}
```

Fixes #356