### PR TITLE
Allow setting a different Logger at runtime 

### DIFF
--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -123,7 +123,9 @@ extern std::shared_ptr<Helper::DiskIO>(*f_createIO)();
 #define IOBINARY(ptr, func, bytes, ...) if (ptr->func(bytes, __VA_ARGS__) != bytes) return ErrorCode::DiskIOFail
 #define IOSTRING(ptr, func, ...) if (ptr->func(__VA_ARGS__) == 0) return ErrorCode::DiskIOFail
 
+extern Helper::LoggerHolder& GetLoggerHolder();
 extern std::shared_ptr<Helper::Logger> GetLogger();
+extern void SetLogger(std::shared_ptr<Helper::Logger>);
 
 #define SPTAGLIB_LOG(l, ...) GetLogger()->Logging("SPTAG", l, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 

--- a/AnnService/inc/Helper/Logging.h
+++ b/AnnService/inc/Helper/Logging.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <fstream>
+#include <shared_mutex>
 
 #pragma warning(disable:4996)
 
@@ -31,6 +32,27 @@ namespace SPTAG
         {
         public:
             virtual void Logging(const char* title, LogLevel level, const char* file, int line, const char* func, const char* format, ...) = 0;
+        };
+
+        class LoggerHolder
+        {
+        private:
+            std::shared_ptr<Logger> m_logger;
+            std::shared_mutex m_mutex;
+        public:
+            LoggerHolder(std::shared_ptr<Logger> logger) : m_logger(logger) {}
+
+            void SetLogger(std::shared_ptr<Logger> p_logger)
+            {
+                std::unique_lock<std::shared_mutex> lock(m_mutex);
+                m_logger = p_logger;
+            }
+
+            std::shared_ptr<Logger> GetLogger()
+            {
+                std::shared_lock<std::shared_mutex> lock(m_mutex);
+                return m_logger;
+            }
         };
 
 

--- a/AnnService/inc/SSDServing/SSDIndex.h
+++ b/AnnService/inc/SSDServing/SSDIndex.h
@@ -176,7 +176,7 @@ namespace SPTAG {
 
                 if (!p_opts.m_logFile.empty())
                 {
-                    GetLogger().reset(new Helper::FileLogger(Helper::LogLevel::LL_Info, p_opts.m_logFile.c_str()));
+                    SetLogger(std::make_shared<Helper::FileLogger>(Helper::LogLevel::LL_Info, p_opts.m_logFile.c_str()));
                 }
                 int numThreads = p_opts.m_iSSDNumberOfThreads;
                 int internalResultNum = p_opts.m_searchInternalResultNum;

--- a/AnnService/src/Server/SearchService.cpp
+++ b/AnnService/src/Server/SearchService.cpp
@@ -84,7 +84,7 @@ SearchService::Initialize(int p_argNum, char* p_args[])
     }
 
     if (!cmdOptions.m_logFile.empty()) {
-        GetLogger().reset(new Helper::FileLogger(Helper::LogLevel::LL_Debug, cmdOptions.m_logFile.c_str()));
+        SetLogger(std::make_shared<Helper::FileLogger>(Helper::LogLevel::LL_Debug, cmdOptions.m_logFile.c_str()));
     }
 
     m_serviceContext.reset(new ServiceContext(cmdOptions.m_configFile));

--- a/Wrappers/WinRT/AnnIndex.h
+++ b/Wrappers/WinRT/AnnIndex.h
@@ -45,7 +45,7 @@ namespace winrt::SPTAG::implementation
 
 
     AnnIndex() {
-      sptag::GetLogger().reset(new sptag::Helper::SimpleLogger(sptag::Helper::LogLevel::LL_Empty));
+      sptag::SetLogger(std::make_shared<sptag::Helper::SimpleLogger>(sptag::Helper::LogLevel::LL_Empty));
       m_index = sptag::VectorIndex::CreateInstance(sptag::IndexAlgoType::BKT, sptag::GetEnumValueType<float>());
     }
     


### PR DESCRIPTION
Atomicicty is needed here because Logger::Logging is not const, so we can mangle things if shared_ptr is not updated atomically. We can use std::atomic<std::shared_ptr> in C++20 and above, and atomic_store/atomic_load otherwise.

Previous code GetLogger().reset() would not work correctly, because it would overwrite the copy of the static ptr, not the magic static s_pLogger inside of GetLogger(). We add an indirection to make it possible to override the static