### PR TITLE
[WinRT] Fix metadata getting truncated at newline

### DIFF
--- a/Wrappers/WinRT/AnnIndex.cpp
+++ b/Wrappers/WinRT/AnnIndex.cpp
@@ -70,9 +70,10 @@ namespace winrt::SPTAG::implementation
     bool p_withMetaIndex{ true };
     bool p_normalized{ true };
 
-    std::uint64_t* offsets = new std::uint64_t[p_num + 1]{ 0 };
-    if (!sptag::MetadataSet::GetMetadataOffsets(p_meta.Data(), p_meta.Length(), offsets, p_num + 1, '\n')) throw winrt::hresult_invalid_argument{};
-    std::shared_ptr<sptag::MetadataSet> meta(new sptag::MemMetadataSet(p_meta, sptag::ByteArray((std::uint8_t*)offsets, (p_num + 1) * sizeof(std::uint64_t), true), (sptag::SizeType)p_num));
+    std::uint64_t* offsets = new std::uint64_t[p_num + 1]{ 0, metadata.size() * sizeof(metadata[0]) };
+    sptag::ByteArray offsetsArray(reinterpret_cast<std::uint8_t*>(offsets), p_num + 1, true);
+    std::shared_ptr<sptag::MemMetadataSet> meta(new sptag::MemMetadataSet(p_meta, offsetsArray, p_num));
+
     if (sptag::ErrorCode::Success != m_index->AddIndex(vectors, meta, p_withMetaIndex, p_normalized)) {
       throw winrt::hresult_error(E_UNEXPECTED);
     }


### PR DESCRIPTION
When storing metadata (in the WinRT projection of sptag), we were truncating at the first '\n' which is problematic when dealing with binary metadata (like zstd-compressed data). Turns out we don't need to use the GetMetadataOffsets function since we're always adding one vector+one metadata at a time. So we will treat the metadata as one continuous chunk of data.