### PR TITLE
add Wait() method to SPTAG::Helper::DiskIO

### DIFF
--- a/AnnService/inc/Helper/AsyncFileReader.h
+++ b/AnnService/inc/Helper/AsyncFileReader.h
@@ -239,6 +239,12 @@ namespace SPTAG
                 return true;
             }
 
+            virtual void Wait(AsyncReadRequest& readRequest)
+            {
+                // currently not used anywhere, effective only when ASYNC_READ is defined and BATCH_READ is not defined
+                throw std::runtime_error("Not implemented");
+            }
+
             virtual bool BatchReadFile(AsyncReadRequest* readRequests, std::uint32_t requestCount)
             {
                 std::uint32_t remaining = requestCount;

--- a/AnnService/inc/Helper/DiskIO.h
+++ b/AnnService/inc/Helper/DiskIO.h
@@ -65,6 +65,9 @@ namespace SPTAG
             virtual std::uint64_t WriteString(const char* buffer, std::uint64_t offset = UINT64_MAX) = 0;
 
             virtual bool ReadFileAsync(AsyncReadRequest& readRequest) { return false; }
+
+            // interface method for waiting for async read to complete when underlying callback support is not available.
+            virtual void Wait(AsyncReadRequest& readRequest) { return; }
             
             virtual bool BatchReadFile(AsyncReadRequest* readRequests, std::uint32_t requestCount) { return false; }
 


### PR DESCRIPTION
add Wait() method to SPTAG::Helper::DiskIO to support situation where the underlying disk IO layer does not support callback.