### PR TITLE
Add [[nodiscard]] to ErrorCode

### DIFF
--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -130,6 +130,7 @@ extern std::shared_ptr<Helper::DiskIO>(*f_createIO)();
 
 #define IOBINARY(ptr, func, bytes, ...) if (ptr->func(bytes, __VA_ARGS__) != bytes) return ErrorCode::DiskIOFail
 #define IOSTRING(ptr, func, ...) if (ptr->func(__VA_ARGS__) == 0) return ErrorCode::DiskIOFail
+#define RETURN_IF_ERROR(expr) { ErrorCode ret = expr; if (ret != ErrorCode::Success) return ret; }
 
 extern Helper::LoggerHolder& GetLoggerHolder();
 extern std::shared_ptr<Helper::Logger> GetLogger();

--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -150,7 +150,7 @@ public:
 #endif
 };
 
-enum class ErrorCode : std::uint16_t
+enum class [[nodiscard]] ErrorCode : std::uint16_t
 {
 #define DefineErrorCode(Name, Value) Name = Value,
 #include "DefinitionList.h"

--- a/AnnService/inc/Core/Common.h
+++ b/AnnService/inc/Core/Common.h
@@ -131,6 +131,7 @@ extern std::shared_ptr<Helper::DiskIO>(*f_createIO)();
 #define IOBINARY(ptr, func, bytes, ...) if (ptr->func(bytes, __VA_ARGS__) != bytes) return ErrorCode::DiskIOFail
 #define IOSTRING(ptr, func, ...) if (ptr->func(__VA_ARGS__) == 0) return ErrorCode::DiskIOFail
 #define RETURN_IF_ERROR(expr) { ErrorCode ret = expr; if (ret != ErrorCode::Success) return ret; }
+#define RETURN_IF_ERROR_WITH_LOG(expr, log_level, ...) { ErrorCode ret = expr; if (ret != ErrorCode::Success) { SPTAGLIB_LOG(log_level, __VA_ARGS__); return ret; } }
 
 extern Helper::LoggerHolder& GetLoggerHolder();
 extern std::shared_ptr<Helper::Logger> GetLogger();

--- a/AnnService/inc/Core/Common/IQuantizer.h
+++ b/AnnService/inc/Core/Common/IQuantizer.h
@@ -39,7 +39,7 @@ namespace SPTAG
 
             virtual ErrorCode LoadQuantizer(std::shared_ptr<Helper::DiskIO> p_in) = 0;
 
-            virtual ErrorCode LoadQuantizer(uint8_t* raw_bytes) = 0;
+            virtual ErrorCode LoadQuantizer(uint8_t* raw_bytes, SizeType num_bytes) = 0;
 
             static std::shared_ptr<IQuantizer> LoadIQuantizer(std::shared_ptr<Helper::DiskIO> p_in);
 

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -532,7 +532,7 @@ break;
                         outnodes[m_iNeighborhoodSize - 1] = -2 - iter->second;
                 }
 
-                if (output != nullptr) newGraph->SaveGraph(output);
+                if (output != nullptr) RETURN_IF_ERROR(newGraph->SaveGraph(output));
                 return ret;
             }
 

--- a/AnnService/inc/Core/Common/NeighborhoodGraph.h
+++ b/AnnService/inc/Core/Common/NeighborhoodGraph.h
@@ -518,7 +518,6 @@ break;
                     ErrorCode internal_ret =index->RefineSearchIndex(query, false);
                     if (internal_ret != ErrorCode::Success) {
                         SPTAGLIB_LOG(Helper::LogLevel::LL_Error, "RefineSearchIndex failed \n");
-                        #pragma omp atomic write
                         ret = internal_ret;
                     }
                     RebuildNeighbors(index, indices[i], outnodes, query.GetResults(), m_iCEF + 1);

--- a/AnnService/inc/Core/VectorIndex.h
+++ b/AnnService/inc/Core/VectorIndex.h
@@ -188,7 +188,7 @@ public:
 
     inline SizeType GetMetaMapping(std::string& meta) const;
 
-    void UpdateMetaMapping(const std::string& meta, SizeType i);
+    ErrorCode UpdateMetaMapping(const std::string& meta, SizeType i);
 
     void BuildMetaMapping(bool p_checkDeleted = true);
 

--- a/AnnService/src/Core/BKT/BKTIndex.cpp
+++ b/AnnService/src/Core/BKT/BKTIndex.cpp
@@ -20,11 +20,13 @@ namespace SPTAG
         template <typename T>
         ErrorCode Index<T>::LoadConfig(Helper::IniReader& p_reader)
         {
+            ErrorCode code = ErrorCode::Success;
 #define DefineBKTParameter(VarName, VarType, DefaultValue, RepresentStr) \
-            SetParameter(RepresentStr, \
+            code = SetParameter(RepresentStr, \
                          p_reader.GetParameter("Index", \
                          RepresentStr, \
                          std::string(#DefaultValue)).c_str()); \
+            if (code != ErrorCode::Success) return code;
 
 #include "inc/Core/BKT/ParameterDefinitionList.h"
 #undef DefineBKTParameter

--- a/AnnService/src/Core/BKT/BKTIndex.cpp
+++ b/AnnService/src/Core/BKT/BKTIndex.cpp
@@ -884,7 +884,6 @@ namespace SPTAG
                 ErrorCode search_ret = SearchIndex(query);
                 if (search_ret != ErrorCode::Success || query.GetResultNum() == 0) {
                     SPTAGLIB_LOG(Helper::LogLevel::LL_Warning, "Cannot find vector to delete!\n");
-                    #pragma omp atomic write
                     ret = search_ret;
                 }
 
@@ -894,7 +893,6 @@ namespace SPTAG
                         ErrorCode delete_ret = DeleteIndex(vid);
                         if (delete_ret != ErrorCode::Success) {
                             SPTAGLIB_LOG(Helper::LogLevel::LL_Warning, "Cannot delete vector! ID: %llu\n", vid);
-                            #pragma omp atomic write
                             ret = delete_ret;
                         }
                     }

--- a/AnnService/src/Core/BKT/BKTIndex.cpp
+++ b/AnnService/src/Core/BKT/BKTIndex.cpp
@@ -952,7 +952,7 @@ namespace SPTAG
                             for (SizeType i = begin; i < end; i++) {
                                 ByteArray meta = m_pMetadata->GetMetadata(i);
                                 std::string metastr((char*)meta.Data(), meta.Length());
-                                UpdateMetaMapping(metastr, i);
+                                RETURN_IF_ERROR(UpdateMetaMapping(metastr, i));
                             }
                         }
                     }

--- a/AnnService/src/Core/Common/IQuantizer.cpp
+++ b/AnnService/src/Core/Common/IQuantizer.cpp
@@ -55,11 +55,14 @@ namespace SPTAG
         std::shared_ptr<IQuantizer> IQuantizer::LoadIQuantizer(SPTAG::ByteArray bytes)
         {
             auto raw_bytes = bytes.Data();
+            SizeType num_bytes = bytes.Length();
             QuantizerType quantizerType = *(QuantizerType*) raw_bytes;
             raw_bytes += sizeof(QuantizerType);
+            num_bytes -= sizeof(QuantizerType);
 
             VectorValueType reconstructType = *(VectorValueType*)raw_bytes;
             raw_bytes += sizeof(VectorValueType);
+            num_bytes -= sizeof(VectorValueType);
             SPTAGLIB_LOG(Helper::LogLevel::LL_Info, "Loading quantizer of type %s with reconstructtype %s.\n", Helper::Convert::ConvertToString<QuantizerType>(quantizerType).c_str(), Helper::Convert::ConvertToString<VectorValueType>(reconstructType).c_str());
             std::shared_ptr<IQuantizer> ret = nullptr;
 
@@ -80,7 +83,7 @@ namespace SPTAG
                 default: break;
                 }
 
-                if (ret->LoadQuantizer(raw_bytes) != ErrorCode::Success) ret.reset();
+                if (ret->LoadQuantizer(raw_bytes, num_bytes) != ErrorCode::Success) ret.reset();
                 return ret;
             case QuantizerType::OPQQuantizer:
                 switch (reconstructType) {
@@ -94,7 +97,7 @@ namespace SPTAG
                 default: break;
                 }
 
-                if (ret->LoadQuantizer(raw_bytes) != ErrorCode::Success) ret.reset();
+                if (ret->LoadQuantizer(raw_bytes, num_bytes) != ErrorCode::Success) ret.reset();
                 return ret;
             }
             return ret;

--- a/AnnService/src/Core/KDT/KDTIndex.cpp
+++ b/AnnService/src/Core/KDT/KDTIndex.cpp
@@ -666,7 +666,7 @@ case VectorValueType::Name: \
                             for (SizeType i = begin; i < end; i++) {
                                 ByteArray meta = m_pMetadata->GetMetadata(i);
                                 std::string metastr((char*)meta.Data(), meta.Length());
-                                UpdateMetaMapping(metastr, i);
+                                RETURN_IF_ERROR(UpdateMetaMapping(metastr, i));
                             }
                         }
                     }

--- a/AnnService/src/Core/SPANN/SPANNIndex.cpp
+++ b/AnnService/src/Core/SPANN/SPANNIndex.cpp
@@ -897,10 +897,10 @@ namespace SPTAG
                 m_index->SetQuantizer(m_pQuantizer);
                 if (!CheckHeadIndexType()) return ErrorCode::Fail;
 
-                m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads));
-                m_index->SetParameter("MaxCheck", std::to_string(m_options.m_maxCheck));
-                m_index->SetParameter("HashTableExponent", std::to_string(m_options.m_hashExp));
-                m_index->UpdateIndex();
+                RETURN_IF_ERROR(m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads)));
+                RETURN_IF_ERROR(m_index->SetParameter("MaxCheck", std::to_string(m_options.m_maxCheck)));
+                RETURN_IF_ERROR(m_index->SetParameter("HashTableExponent", std::to_string(m_options.m_hashExp)));
+                RETURN_IF_ERROR(m_index->UpdateIndex());
 
                 if (m_pQuantizer)
                 {

--- a/AnnService/src/Core/SPANN/SPANNIndex.cpp
+++ b/AnnService/src/Core/SPANN/SPANNIndex.cpp
@@ -1021,11 +1021,20 @@ namespace SPTAG
             Index<T>::UpdateIndex()
         {
             omp_set_num_threads(m_options.m_iSSDNumberOfThreads);
-            m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads));
+            ErrorCode ret = m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads));
+            if (ret != ErrorCode::Success)
+            {
+                SPTAGLIB_LOG(Helper::LogLevel::LL_Error, "Failed to set NumberOfThreads parameter to %d\n", m_options.m_iSSDNumberOfThreads);
+                return ret;
+            }
             //m_index->SetParameter("MaxCheck", std::to_string(m_options.m_maxCheck));
             //m_index->SetParameter("HashTableExponent", std::to_string(m_options.m_hashExp));
-            m_index->UpdateIndex();
-            return ErrorCode::Success;
+            ret = m_index->UpdateIndex();
+            if (ret != ErrorCode::Success)
+            {
+                SPTAGLIB_LOG(Helper::LogLevel::LL_Error, "Failed to update index\n");
+            }
+            return ret;
         }
 
         template <typename T>

--- a/AnnService/src/Core/SPANN/SPANNIndex.cpp
+++ b/AnnService/src/Core/SPANN/SPANNIndex.cpp
@@ -751,7 +751,11 @@ namespace SPTAG
                     bktFileNameBuilder << m_options.m_vectorPath << ".bkt." << m_options.m_iBKTKmeansK << "_"
                         << m_options.m_iBKTLeafSize << "_" << m_options.m_iTreeNumber << "_" << m_options.m_iSamples << "_"
                         << static_cast<int>(m_options.m_distCalcMethod) << ".bin";
-                    bkt->SaveTrees(bktFileNameBuilder.str());
+                    ErrorCode saveTreesRet = bkt->SaveTrees(bktFileNameBuilder.str());
+                    if (saveTreesRet != ErrorCode::Success) {
+                        SPTAGLIB_LOG(Helper::LogLevel::LL_Error, "Failed to save BKT to file %s\n", bktFileNameBuilder.str().c_str());
+                        return false;
+                    }
                 }
                 SPTAGLIB_LOG(Helper::LogLevel::LL_Info, "Finish generating BKT.\n");
 
@@ -851,11 +855,11 @@ namespace SPTAG
                 auto dims = m_pQuantizer ? m_pQuantizer->GetNumSubvectors() : m_options.m_dim;
 
                 m_index = SPTAG::VectorIndex::CreateInstance(m_options.m_indexAlgoType, valueType);
-                m_index->SetParameter("DistCalcMethod", SPTAG::Helper::Convert::ConvertToString(m_options.m_distCalcMethod));
+                RETURN_IF_ERROR(m_index->SetParameter("DistCalcMethod", SPTAG::Helper::Convert::ConvertToString(m_options.m_distCalcMethod)));
                 m_index->SetQuantizer(m_pQuantizer);
                 for (const auto& iter : m_headParameters)
                 {
-                    m_index->SetParameter(iter.first.c_str(), iter.second.c_str());
+                    RETURN_IF_ERROR(m_index->SetParameter(iter.first.c_str(), iter.second.c_str()));
                 }
 
                 std::shared_ptr<Helper::ReaderOptions> vectorOptions(new Helper::ReaderOptions(valueType, dims, VectorFileType::DEFAULT));
@@ -1046,7 +1050,7 @@ namespace SPTAG
                 else m_headParameters[p_param] = p_value;
             }
             else {
-                m_options.SetParameter(p_section, p_param, p_value);
+                RETURN_IF_ERROR(m_options.SetParameter(p_section, p_param, p_value));
             }
             if (SPTAG::Helper::StrUtils::StrEqualIgnoreCase(p_param, "DistCalcMethod")) {
                 if (m_pQuantizer)

--- a/AnnService/src/Core/SPANN/SPANNIndex.cpp
+++ b/AnnService/src/Core/SPANN/SPANNIndex.cpp
@@ -66,7 +66,7 @@ namespace SPTAG
             for (int i = 0; i < 4; i++) {
                 auto parameters = p_reader.GetParameters(sections[i].c_str());
                 for (auto iter = parameters.begin(); iter != parameters.end(); iter++) {
-                    SetParameter(iter->first.c_str(), iter->second.c_str(), sections[i].c_str());
+                    RETURN_IF_ERROR(SetParameter(iter->first.c_str(), iter->second.c_str(), sections[i].c_str()));
                 }
             }
 
@@ -84,10 +84,10 @@ namespace SPTAG
             m_index->SetQuantizer(m_pQuantizer);
             if (m_index->LoadIndexDataFromMemory(p_indexBlobs) != ErrorCode::Success) return ErrorCode::Fail;
 
-            m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads));
+            RETURN_IF_ERROR(m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads)));
             //m_index->SetParameter("MaxCheck", std::to_string(m_options.m_maxCheck));
             //m_index->SetParameter("HashTableExponent", std::to_string(m_options.m_hashExp));
-            m_index->UpdateIndex();
+            RETURN_IF_ERROR(m_index->UpdateIndex());
             m_index->SetReady(true);
 
             if (m_pQuantizer)
@@ -113,10 +113,10 @@ namespace SPTAG
             m_index->SetQuantizer(m_pQuantizer);
             if (m_index->LoadIndexData(p_indexStreams) != ErrorCode::Success) return ErrorCode::Fail;
 
-            m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads));
+            RETURN_IF_ERROR(m_index->SetParameter("NumberOfThreads", std::to_string(m_options.m_iSSDNumberOfThreads)));
             //m_index->SetParameter("MaxCheck", std::to_string(m_options.m_maxCheck));
             //m_index->SetParameter("HashTableExponent", std::to_string(m_options.m_hashExp));
-            m_index->UpdateIndex();
+            RETURN_IF_ERROR(m_index->UpdateIndex());
             m_index->SetReady(true);
 
             if (m_pQuantizer)
@@ -161,7 +161,7 @@ namespace SPTAG
 #include "inc/Core/SPANN/ParameterDefinitionList.h"
 #undef DefineBuildHeadParameter
 
-            m_index->SaveConfig(p_configOut);
+            RETURN_IF_ERROR_WITH_LOG(m_index->SaveConfig(p_configOut), Helper::LogLevel::LL_Error, "Failed to save head index config.\n");
 
             Helper::Convert::ConvertStringTo<int>(m_index->GetParameter("HashTableExponent").c_str(), m_options.m_hashExp);
             IOSTRING(p_configOut, WriteString, "[BuildSSDIndex]\n");
@@ -200,7 +200,7 @@ namespace SPTAG
             else
                 p_queryResults = new COMMON::QueryResultSet<T>((const T*)p_query.GetTarget(), m_options.m_searchInternalResultNum);
 
-            m_index->SearchIndex(*p_queryResults);
+            RETURN_IF_ERROR(m_index->SearchIndex(*p_queryResults));
             
             if (m_extraSearcher != nullptr) {
                 auto workSpace = m_workSpaceFactory->GetWorkSpace();

--- a/AnnService/src/Core/VectorIndex.cpp
+++ b/AnnService/src/Core/VectorIndex.cpp
@@ -232,13 +232,14 @@ VectorIndex::GetMetaMapping(std::string& meta) const
 }
 
 
-void
+ErrorCode
 VectorIndex::UpdateMetaMapping(const std::string& meta, SizeType i)
 {
     MetadataMap* ptr = static_cast<MetadataMap*>(m_pMetaToVec.get());
     auto iter = ptr->find(meta);
-    if (iter != ptr->end()) DeleteIndex(iter->second);;
+    if (iter != ptr->end()) RETURN_IF_ERROR(DeleteIndex(iter->second));
     (*ptr)[meta] = i;
+    return ErrorCode::Success;
 }
 
 


### PR DESCRIPTION
There are many places in SPTAG where we silently discard errors. This change adds [[nodiscard]] to ErrorCode to issue compiler warnings whenever it is not used by the caller, and adds some changes to properly check ErrorCode.