### PR TITLE
Add compact official RaBitQ integration

### DIFF
--- a/AnnService/inc/Core/Common/RaBitQQuantizer.h
+++ b/AnnService/inc/Core/Common/RaBitQQuantizer.h
@@ -7,6 +7,7 @@
 #include "inc/Core/VectorSet.h"
 
 #include "rabitqlib/quantization/rabitq.hpp"
+#include "rabitqlib/utils/space.hpp"
 
 #include <memory>
 #include <vector>
@@ -16,7 +17,7 @@ namespace SPTAG
 namespace COMMON
 {
 
-// Global RaBitQ adapter backed by the official scalar quantizer API.
+// Global RaBitQ adapter backed by the official full-code quantizer and estimator.
 class RaBitQQuantizer : public IQuantizer
 {
 public:
@@ -54,25 +55,40 @@ private:
         std::uint32_t magic;
         std::uint32_t version;
         std::int32_t dimension;
+        std::int32_t paddedDimension;
         std::int32_t bits;
         std::uint32_t normalize;
     };
 
-    static constexpr std::uint32_t kModelMagic = 0x31534252U; // RBS1
-    static constexpr std::uint32_t kModelVersion = 1U;
+    static constexpr std::uint32_t kModelMagic = 0x32464252U; // RBF2
+    static constexpr std::uint32_t kModelVersion = 2U;
+    static constexpr std::size_t kCodeFactorCount = 5;
+    static constexpr std::size_t kQueryFactorCount = 2;
 
     ErrorCode Initialize(DimensionType p_dimension, int p_bits, bool p_normalize);
     ErrorCode LoadHeader(const ModelHeader& p_header);
     void Decode(const std::uint8_t* p_code, std::vector<float>& p_output) const;
-    void CopyInput(const float* p_input, float* p_output) const;
-    void ReadCodeParameters(const std::uint8_t* p_code, float& p_delta, float& p_lower_value) const;
+    void PrepareInput(const float* p_input, std::vector<float>& p_output) const;
+    void UnpackCode(const std::uint8_t* p_code, std::uint8_t* p_output) const;
+    void ReadCodeFactors(const std::uint8_t* p_code,
+                         float& p_f_add,
+                         float& p_f_rescale,
+                         float& p_f_error,
+                         float& p_delta,
+                         float& p_lower_value) const;
+    void ReadDistanceFactors(const std::uint8_t* p_code,
+                             float& p_f_add,
+                             float& p_f_rescale) const;
+    std::size_t PackedCodeBytes() const;
     std::size_t CodeBytes() const;
 
     DimensionType m_dimension = 0;
+    DimensionType m_padded_dimension = 0;
     int m_bits = 0;
     bool m_normalize = false;
     bool m_enable_adc = false;
     rabitqlib::quant::RabitqConfig m_quantizer_config;
+    rabitqlib::ex_ipfunc m_ip_func = nullptr;
     std::vector<float> m_centroid;
 };
 

--- a/AnnService/src/Core/Common/RaBitQQuantizer.cpp
+++ b/AnnService/src/Core/Common/RaBitQQuantizer.cpp
@@ -3,11 +3,14 @@
 
 #include "inc/Core/Common/RaBitQQuantizer.h"
 
-#include "inc/Core/Common/DistanceUtils.h"
+#include "rabitqlib/quantization/data_layout.hpp"
+#include "rabitqlib/quantization/pack_excode.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <limits>
+#include <numeric>
 #include <stdexcept>
 
 namespace SPTAG
@@ -29,12 +32,15 @@ ErrorCode RaBitQQuantizer::Initialize(DimensionType p_dimension, int p_bits, boo
     }
 
     m_dimension = p_dimension;
+    m_padded_dimension = static_cast<DimensionType>(
+        (static_cast<std::size_t>(p_dimension) + 63U) / 64U * 64U);
     m_bits = p_bits;
     m_normalize = p_normalize;
     m_enable_adc = false;
-    m_centroid.assign(static_cast<std::size_t>(m_dimension), 0.0F);
+    m_centroid.assign(static_cast<std::size_t>(m_padded_dimension), 0.0F);
     m_quantizer_config = rabitqlib::quant::faster_config(
-        static_cast<std::size_t>(m_dimension), static_cast<std::size_t>(m_bits));
+        static_cast<std::size_t>(m_padded_dimension), static_cast<std::size_t>(m_bits));
+    m_ip_func = rabitqlib::select_excode_ipfunc(static_cast<std::size_t>(m_bits));
     return ErrorCode::Success;
 }
 
@@ -46,16 +52,12 @@ ErrorCode RaBitQQuantizer::Train(const std::shared_ptr<VectorSet>& p_vectors)
     }
 
     std::vector<double> accumulator(static_cast<std::size_t>(m_dimension), 0.0);
-    std::vector<float> normalized(static_cast<std::size_t>(m_dimension));
+    std::vector<float> prepared;
     for (SizeType i = 0; i < p_vectors->Count(); ++i) {
         const auto* vector = static_cast<const float*>(p_vectors->GetVector(i));
-        const float* input = vector;
-        if (m_normalize) {
-            CopyInput(vector, normalized.data());
-            input = normalized.data();
-        }
+        PrepareInput(vector, prepared);
         for (DimensionType j = 0; j < m_dimension; ++j) {
-            accumulator[static_cast<std::size_t>(j)] += input[j];
+            accumulator[static_cast<std::size_t>(j)] += prepared[static_cast<std::size_t>(j)];
         }
     }
 
@@ -69,98 +71,161 @@ ErrorCode RaBitQQuantizer::Train(const std::shared_ptr<VectorSet>& p_vectors)
 
 float RaBitQQuantizer::L2Distance(const std::uint8_t* p_x, const std::uint8_t* p_y) const
 {
-    thread_local std::vector<float> left;
-    thread_local std::vector<float> right;
-    Decode(p_y, right);
-    if (m_enable_adc) {
-        return DistanceUtils::ComputeL2Distance(
-            reinterpret_cast<const float*>(p_x), right.data(), m_dimension);
+    thread_local std::vector<float> reconstructed_query;
+    const float* query = reinterpret_cast<const float*>(p_x);
+    float g_add = 0.0F;
+    float k1xsumq = 0.0F;
+    if (!m_enable_adc) {
+        Decode(p_x, reconstructed_query);
+        query = reconstructed_query.data();
+        g_add = rabitqlib::euclidean_sqr(
+            query, m_centroid.data(), static_cast<std::size_t>(m_padded_dimension));
+        k1xsumq = -0.5F * std::accumulate(
+            query, query + m_padded_dimension, 0.0F);
+    } else {
+        const std::uint8_t* query_factors =
+            p_x + static_cast<std::size_t>(m_padded_dimension) * sizeof(float);
+        std::memcpy(&g_add, query_factors, sizeof(float));
+        std::memcpy(&k1xsumq, query_factors + sizeof(float), sizeof(float));
     }
 
-    Decode(p_x, left);
-    return DistanceUtils::ComputeL2Distance(left.data(), right.data(), m_dimension);
+    float f_add = 0.0F;
+    float f_rescale = 0.0F;
+    ReadDistanceFactors(p_y, f_add, f_rescale);
+    return rabitqlib::quant::full_est_dist<float, std::uint8_t>(
+        p_y,
+        query,
+        m_ip_func,
+        static_cast<std::size_t>(m_padded_dimension),
+        static_cast<std::size_t>(m_bits),
+        f_add,
+        f_rescale,
+        g_add,
+        k1xsumq);
 }
 
 float RaBitQQuantizer::CosineDistance(const std::uint8_t* p_x, const std::uint8_t* p_y) const
 {
-    thread_local std::vector<float> left;
-    thread_local std::vector<float> right;
-    Decode(p_y, right);
-    if (m_enable_adc) {
-        left.assign(reinterpret_cast<const float*>(p_x),
-                    reinterpret_cast<const float*>(p_x) + m_dimension);
-    } else {
-        Decode(p_x, left);
-    }
-
-    double dot = 0.0;
-    double left_norm = 0.0;
-    double right_norm = 0.0;
-    for (DimensionType i = 0; i < m_dimension; ++i) {
-        dot += static_cast<double>(left[static_cast<std::size_t>(i)]) * right[static_cast<std::size_t>(i)];
-        left_norm += static_cast<double>(left[static_cast<std::size_t>(i)]) * left[static_cast<std::size_t>(i)];
-        right_norm += static_cast<double>(right[static_cast<std::size_t>(i)]) * right[static_cast<std::size_t>(i)];
-    }
-    if (left_norm <= 0.0 || right_norm <= 0.0) {
-        return 1.0F;
-    }
-    return 1.0F - static_cast<float>(dot / std::sqrt(left_norm * right_norm));
+    SPTAGLIB_LOG(Helper::LogLevel::LL_Error,
+                 "RaBitQ official full-code adapter supports L2 distance only.\n");
+    return std::numeric_limits<float>::infinity();
 }
 
 void RaBitQQuantizer::QuantizeVector(const void* p_vector, std::uint8_t* p_output, bool p_adc) const
 {
-    const auto* input = static_cast<const float*>(p_vector);
-    thread_local std::vector<float> normalized;
-    if (m_normalize) {
-        normalized.resize(static_cast<std::size_t>(m_dimension));
-        CopyInput(input, normalized.data());
-        input = normalized.data();
-    }
+    thread_local std::vector<float> prepared;
+    PrepareInput(static_cast<const float*>(p_vector), prepared);
+    const float* input = prepared.data();
 
     if (p_adc && m_enable_adc) {
-        std::memcpy(p_output, input, static_cast<std::size_t>(m_dimension) * sizeof(float));
+        const std::size_t query_bytes =
+            static_cast<std::size_t>(m_padded_dimension) * sizeof(float);
+        std::memcpy(p_output, input, query_bytes);
+        const float g_add = rabitqlib::euclidean_sqr(
+            input, m_centroid.data(), static_cast<std::size_t>(m_padded_dimension));
+        const float k1xsumq = -0.5F * std::accumulate(
+            input, input + m_padded_dimension, 0.0F);
+        std::memcpy(p_output + query_bytes, &g_add, sizeof(float));
+        std::memcpy(p_output + query_bytes + sizeof(float), &k1xsumq, sizeof(float));
         return;
     }
 
     bool zero_residual = true;
-    for (DimensionType i = 0; i < m_dimension; ++i) {
+    for (DimensionType i = 0; i < m_padded_dimension; ++i) {
         if (input[i] != m_centroid[static_cast<std::size_t>(i)]) {
             zero_residual = false;
             break;
         }
     }
-    std::memset(p_output, 0, static_cast<std::size_t>(m_dimension));
+    std::memset(p_output, 0, CodeBytes());
+    float f_add = 0.0F;
+    float f_rescale = 0.0F;
+    float f_error = 0.0F;
     float delta = 0.0F;
     float lower_value = 0.0F;
-    if (zero_residual) {
-        std::memcpy(p_output + m_dimension, &delta, sizeof(delta));
-        std::memcpy(p_output + m_dimension + sizeof(delta), &lower_value, sizeof(lower_value));
-        return;
+    if (!zero_residual) {
+        thread_local std::vector<std::uint8_t> scalar_code;
+        thread_local std::vector<std::uint8_t> full_code;
+        scalar_code.assign(static_cast<std::size_t>(m_padded_dimension), 0);
+        full_code.assign(static_cast<std::size_t>(m_padded_dimension), 0);
+
+        rabitqlib::quant::quantize_scalar<float, std::uint8_t>(
+            input,
+            m_centroid.data(),
+            static_cast<std::size_t>(m_padded_dimension),
+            static_cast<std::size_t>(m_bits),
+            scalar_code.data(),
+            delta,
+            lower_value,
+            m_quantizer_config);
+
+        if (m_bits == 1) {
+            std::vector<char> bin_data(
+                rabitqlib::BinDataMap<float>::data_bytes(
+                    static_cast<std::size_t>(m_padded_dimension)));
+            rabitqlib::quant::quantize_compact_one_bit(
+                input,
+                m_centroid.data(),
+                static_cast<std::size_t>(m_padded_dimension),
+                bin_data.data(),
+                rabitqlib::METRIC_L2);
+            rabitqlib::ConstBinDataMap<float> bin(
+                bin_data.data(), static_cast<std::size_t>(m_padded_dimension));
+            rabitqlib::quant::rabitq_impl::ex_bits::packing_rabitqplus_code(
+                scalar_code.data(),
+                p_output,
+                static_cast<std::size_t>(m_padded_dimension),
+                1);
+            f_add = bin.f_add();
+            f_rescale = bin.f_rescale();
+            f_error = bin.f_error();
+        } else {
+            rabitqlib::quant::quantize_full_single<float, std::uint8_t>(
+                input,
+                m_centroid.data(),
+                static_cast<std::size_t>(m_padded_dimension),
+                static_cast<std::size_t>(m_bits),
+                full_code.data(),
+                f_add,
+                f_rescale,
+                f_error,
+                rabitqlib::METRIC_L2,
+                m_quantizer_config);
+            if (scalar_code != full_code) {
+                throw std::runtime_error(
+                    "Official RaBitQ scalar and full-code quantizers produced different codes");
+            }
+            rabitqlib::quant::rabitq_impl::ex_bits::packing_rabitqplus_code(
+                full_code.data(),
+                p_output,
+                static_cast<std::size_t>(m_padded_dimension),
+                static_cast<std::size_t>(m_bits));
+        }
     }
 
-    rabitqlib::quant::quantize_scalar<float, std::uint8_t>(
-        input,
-        m_centroid.data(),
-        static_cast<std::size_t>(m_dimension),
-        static_cast<std::size_t>(m_bits),
-        p_output,
-        delta,
-        lower_value,
-        m_quantizer_config);
-    std::memcpy(p_output + m_dimension, &delta, sizeof(delta));
-    std::memcpy(p_output + m_dimension + sizeof(delta), &lower_value, sizeof(lower_value));
+    std::uint8_t* factors = p_output + PackedCodeBytes();
+    std::memcpy(factors, &f_add, sizeof(f_add));
+    std::memcpy(factors + sizeof(float), &f_rescale, sizeof(f_rescale));
+    std::memcpy(factors + 2 * sizeof(float), &f_error, sizeof(f_error));
+    std::memcpy(factors + 3 * sizeof(float), &delta, sizeof(delta));
+    std::memcpy(factors + 4 * sizeof(float), &lower_value, sizeof(lower_value));
 }
 
 int RaBitQQuantizer::QuantizeSize() const
 {
-    return m_enable_adc ? static_cast<int>(sizeof(float) * m_dimension) : static_cast<int>(CodeBytes());
+    return m_enable_adc
+        ? static_cast<int>(
+              sizeof(float) *
+              (static_cast<std::size_t>(m_padded_dimension) + kQueryFactorCount))
+        : static_cast<int>(CodeBytes());
 }
 
 void RaBitQQuantizer::ReconstructVector(const std::uint8_t* p_code, void* p_output) const
 {
     thread_local std::vector<float> reconstructed;
     Decode(p_code, reconstructed);
-    std::memcpy(p_output, reconstructed.data(), static_cast<std::size_t>(m_dimension) * sizeof(float));
+    std::memcpy(
+        p_output, reconstructed.data(), static_cast<std::size_t>(m_dimension) * sizeof(float));
 }
 
 int RaBitQQuantizer::ReconstructSize() const
@@ -191,6 +256,7 @@ ErrorCode RaBitQQuantizer::SaveQuantizer(std::shared_ptr<Helper::DiskIO> p_outpu
         kModelMagic,
         kModelVersion,
         m_dimension,
+        m_padded_dimension,
         m_bits,
         m_normalize ? 1U : 0U,
     };
@@ -274,63 +340,177 @@ float* RaBitQQuantizer::GetL2DistanceTables()
 bool RaBitQQuantizer::Ready() const
 {
     return m_dimension > 0 && m_bits >= 1 && m_bits <= 8 &&
-        m_centroid.size() == static_cast<std::size_t>(m_dimension);
+        m_padded_dimension >= m_dimension && m_padded_dimension % 64 == 0 &&
+        m_centroid.size() == static_cast<std::size_t>(m_padded_dimension) &&
+        m_ip_func != nullptr;
 }
 
 ErrorCode RaBitQQuantizer::LoadHeader(const ModelHeader& p_header)
 {
     if (p_header.magic != kModelMagic || p_header.version != kModelVersion ||
-        p_header.dimension <= 0 || p_header.bits < 1 || p_header.bits > 8) {
+        p_header.dimension <= 0 || p_header.paddedDimension < p_header.dimension ||
+        p_header.paddedDimension % 64 != 0 || p_header.bits < 1 || p_header.bits > 8) {
         return ErrorCode::FailedParseValue;
     }
-    return Initialize(p_header.dimension, p_header.bits, p_header.normalize != 0);
+    const ErrorCode status =
+        Initialize(p_header.dimension, p_header.bits, p_header.normalize != 0);
+    return status == ErrorCode::Success && m_padded_dimension == p_header.paddedDimension
+        ? ErrorCode::Success
+        : ErrorCode::FailedParseValue;
 }
 
 void RaBitQQuantizer::Decode(const std::uint8_t* p_code, std::vector<float>& p_output) const
 {
+    float f_add = 0.0F;
+    float f_rescale = 0.0F;
+    float f_error = 0.0F;
     float delta = 0.0F;
     float lower_value = 0.0F;
-    ReadCodeParameters(p_code, delta, lower_value);
-    p_output.resize(static_cast<std::size_t>(m_dimension));
+    ReadCodeFactors(
+        p_code, f_add, f_rescale, f_error, delta, lower_value);
+
+    thread_local std::vector<std::uint8_t> unpacked;
+    unpacked.resize(static_cast<std::size_t>(m_padded_dimension));
+    UnpackCode(p_code, unpacked.data());
+    p_output.resize(static_cast<std::size_t>(m_padded_dimension));
     rabitqlib::quant::reconstruct_vec<float, std::uint8_t>(
-        p_code,
+        unpacked.data(),
         delta,
         lower_value,
-        static_cast<std::size_t>(m_dimension),
+        static_cast<std::size_t>(m_padded_dimension),
         p_output.data());
-    for (DimensionType i = 0; i < m_dimension; ++i) {
+    for (DimensionType i = 0; i < m_padded_dimension; ++i) {
         p_output[static_cast<std::size_t>(i)] += m_centroid[static_cast<std::size_t>(i)];
     }
+    std::fill(
+        p_output.begin() + static_cast<std::size_t>(m_dimension), p_output.end(), 0.0F);
 }
 
-void RaBitQQuantizer::CopyInput(const float* p_input, float* p_output) const
+void RaBitQQuantizer::PrepareInput(
+    const float* p_input, std::vector<float>& p_output) const
 {
+    p_output.assign(static_cast<std::size_t>(m_padded_dimension), 0.0F);
+    std::copy(p_input, p_input + m_dimension, p_output.begin());
+    if (!m_normalize) {
+        return;
+    }
+
     double norm = 0.0;
     for (DimensionType i = 0; i < m_dimension; ++i) {
         norm += static_cast<double>(p_input[i]) * p_input[i];
     }
     if (norm == 0.0) {
-        std::memset(p_output, 0, static_cast<std::size_t>(m_dimension) * sizeof(float));
         return;
     }
 
     const float inverse_norm = static_cast<float>(1.0 / std::sqrt(norm));
     for (DimensionType i = 0; i < m_dimension; ++i) {
-        p_output[i] = p_input[i] * inverse_norm;
+        p_output[static_cast<std::size_t>(i)] = p_input[i] * inverse_norm;
     }
 }
 
-void RaBitQQuantizer::ReadCodeParameters(const std::uint8_t* p_code,
-                                         float& p_delta,
-                                         float& p_lower_value) const
+void RaBitQQuantizer::UnpackCode(
+    const std::uint8_t* p_code, std::uint8_t* p_output) const
 {
-    std::memcpy(&p_delta, p_code + m_dimension, sizeof(p_delta));
-    std::memcpy(&p_lower_value, p_code + m_dimension + sizeof(p_delta), sizeof(p_lower_value));
+    const std::size_t dim = static_cast<std::size_t>(m_padded_dimension);
+    std::memset(p_output, 0, dim);
+    if (m_bits == 8) {
+        std::memcpy(p_output, p_code, dim);
+        return;
+    }
+    if (m_bits == 1) {
+        for (std::size_t i = 0; i < dim; ++i) {
+            p_output[i] = static_cast<std::uint8_t>((p_code[i / 8] >> (i % 8)) & 1U);
+        }
+        return;
+    }
+
+    for (std::size_t block = 0; block < dim; block += 64) {
+        const std::uint8_t* packed =
+            p_code + block * static_cast<std::size_t>(m_bits) / 8;
+        std::uint8_t* output = p_output + block;
+        if (m_bits == 2 || m_bits == 3) {
+            for (std::size_t i = 0; i < 64; ++i) {
+                output[i] = static_cast<std::uint8_t>(
+                    (packed[i % 16] >> (2 * (i / 16))) & 0x3U);
+                if (m_bits == 3) {
+                    output[i] |= static_cast<std::uint8_t>(
+                        ((packed[16 + (i % 8)] >> (i / 8)) & 1U) << 2);
+                }
+            }
+        } else if (m_bits == 4) {
+            for (std::size_t i = 0; i < 64; ++i) {
+                const std::size_t group = i / 16;
+                const std::size_t within_group = i % 16;
+                output[i] = static_cast<std::uint8_t>(
+                    (packed[group * 8 + (within_group % 8)] >>
+                     (4 * (within_group / 8))) &
+                    0xFU);
+            }
+        } else if (m_bits == 5) {
+            for (std::size_t i = 0; i < 64; ++i) {
+                const std::size_t half = i / 32;
+                const std::size_t within_half = i % 32;
+                output[i] = static_cast<std::uint8_t>(
+                    (packed[half * 16 + (within_half % 16)] >>
+                     (4 * (within_half / 16))) &
+                    0xFU);
+                output[i] |= static_cast<std::uint8_t>(
+                    ((packed[32 + (i % 8)] >> (i / 8)) & 1U) << 4);
+            }
+        } else {
+            for (std::size_t i = 0; i < 48; ++i) {
+                output[i] = static_cast<std::uint8_t>(packed[i] & 0x3FU);
+            }
+            for (std::size_t lane = 0; lane < 16; ++lane) {
+                output[48 + lane] = static_cast<std::uint8_t>(
+                    ((packed[lane] >> 6) & 0x3U) |
+                    (((packed[16 + lane] >> 6) & 0x3U) << 2) |
+                    (((packed[32 + lane] >> 6) & 0x3U) << 4));
+            }
+            if (m_bits == 7) {
+                for (std::size_t i = 0; i < 64; ++i) {
+                    output[i] |= static_cast<std::uint8_t>(
+                        ((packed[48 + (i % 8)] >> (i / 8)) & 1U) << 6);
+                }
+            }
+        }
+    }
+}
+
+void RaBitQQuantizer::ReadCodeFactors(const std::uint8_t* p_code,
+                                      float& p_f_add,
+                                      float& p_f_rescale,
+                                      float& p_f_error,
+                                      float& p_delta,
+                                      float& p_lower_value) const
+{
+    const std::uint8_t* factors = p_code + PackedCodeBytes();
+    std::memcpy(&p_f_add, factors, sizeof(float));
+    std::memcpy(&p_f_rescale, factors + sizeof(float), sizeof(float));
+    std::memcpy(&p_f_error, factors + 2 * sizeof(float), sizeof(float));
+    std::memcpy(&p_delta, factors + 3 * sizeof(float), sizeof(float));
+    std::memcpy(&p_lower_value, factors + 4 * sizeof(float), sizeof(float));
+}
+
+void RaBitQQuantizer::ReadDistanceFactors(const std::uint8_t* p_code,
+                                          float& p_f_add,
+                                          float& p_f_rescale) const
+{
+    const std::uint8_t* factors = p_code + PackedCodeBytes();
+    std::memcpy(&p_f_add, factors, sizeof(float));
+    std::memcpy(&p_f_rescale, factors + sizeof(float), sizeof(float));
+}
+
+std::size_t RaBitQQuantizer::PackedCodeBytes() const
+{
+    return static_cast<std::size_t>(m_padded_dimension) *
+        static_cast<std::size_t>(m_bits) / 8U;
 }
 
 std::size_t RaBitQQuantizer::CodeBytes() const
 {
-    return static_cast<std::size_t>(m_dimension) + 2 * sizeof(float);
+    return PackedCodeBytes() + kCodeFactorCount * sizeof(float);
 }
 
 } // namespace COMMON

--- a/Script_AE/iniFile/build_SPANN_sift1m_rabitq3_global.ini
+++ b/Script_AE/iniFile/build_SPANN_sift1m_rabitq3_global.ini
@@ -2,7 +2,7 @@
 ValueType=UInt8
 DistCalcMethod=L2
 IndexAlgoType=BKT
-Dim=136
+Dim=68
 VectorPath=/datadisk/yfcc_fast/sptag_rabitq_parity_sift1m_rabitq3/sift_base.rabitq3.u8bin
 VectorType=DEFAULT
 VectorSize=1000000
@@ -12,7 +12,7 @@ WarmupPath=/home/v-mochengli/datasets/sift1m/sift/sift_query.fvecs
 WarmupType=XVEC
 TruthPath=/home/v-mochengli/datasets/sift1m/sift/sift_groundtruth.ivecs
 TruthType=XVEC
-IndexDirectory=/datadisk/yfcc_fast/sptag_rabitq_parity_sift1m_rabitq3/index_u8
+IndexDirectory=/datadisk/yfcc_fast/sptag_rabitq_parity_sift1m_rabitq3/index_static
 QuantizerFilePath=/datadisk/yfcc_fast/sptag_rabitq_parity_sift1m_rabitq3/official_rabitq3_global.bin
 
 [SelectHead]
@@ -43,24 +43,24 @@ BKTLambdaFactor=-1
 [BuildSSDIndex]
 isExecute=true
 BuildSsdIndex=true
-Storage=FILEIO
+Storage=STATIC
 InternalResultNum=64
 ReplicaCount=8
 PostingPageLimit=12
 NumberOfThreads=24
 MaxCheck=8192
 TmpDir=/datadisk/yfcc_fast/sptag_rabitq_parity_sift1m_rabitq3/tmp
-StartFileSizeGB=1
-MaxFileSizeGB=2
-GrowthFileSizeGB=1
+EnableDeltaEncoding=false
+EnablePostingListRearrange=false
+EnableDataCompression=false
+PostingQuantizer=None
 Rerank=0
 EnableADC=true
-AsyncMergeInSearch=false
 
 [SearchSSDIndex]
 isExecute=true
 BuildSsdIndex=false
-QueryCountLimit=1000
+QueryCountLimit=10000
 InternalResultNum=32
 SearchThreadNum=1
 HashTableExponent=4

--- a/Test/src/RaBitQQuantizerTest.cpp
+++ b/Test/src/RaBitQQuantizerTest.cpp
@@ -27,6 +27,8 @@ namespace
 constexpr SizeType kVectorCount = 96;
 constexpr DimensionType kDimension = 128;
 constexpr int kRaBitQBits = 3;
+constexpr DimensionType kRaBitQCodeBytes =
+    kDimension * kRaBitQBits / 8 + 5 * sizeof(float);
 constexpr const char* kQuantizerFile = "rabitq_global_quantizer_test.bin";
 constexpr const char* kQueryFile = "rabitq_global_query_test.fvecs";
 constexpr SizeType kSearchQueryCount = 16;
@@ -268,25 +270,17 @@ void VerifySSDServingSearch(
 
 BOOST_AUTO_TEST_SUITE(RaBitQQuantizerTest)
 
-BOOST_AUTO_TEST_CASE(OfficialScalarRaBitQUsesGlobalQuantizerPath)
+BOOST_AUTO_TEST_CASE(OfficialCompactRaBitQUsesGlobalQuantizerPath)
 {
     std::remove(kQuantizerFile);
     const auto raw = MakeRawVectors();
     auto quantizer = std::make_shared<COMMON::RaBitQQuantizer>(
         kDimension, kRaBitQBits, false);
     BOOST_REQUIRE(quantizer->Train(raw) == ErrorCode::Success);
-    BOOST_CHECK_EQUAL(quantizer->GetNumSubvectors(), kDimension + 8);
+    BOOST_CHECK_EQUAL(quantizer->GetNumSubvectors(), kRaBitQCodeBytes);
 
     const auto codes = QuantizeVectors(raw, quantizer);
-    for (SizeType vector = 0; vector < codes->Count(); ++vector) {
-        float delta = 0.0F;
-        float lower_value = 0.0F;
-        const auto* code = reinterpret_cast<const std::uint8_t*>(codes->GetVector(vector));
-        std::memcpy(&delta, code + kDimension, sizeof(delta));
-        std::memcpy(&lower_value, code + kDimension + sizeof(delta), sizeof(lower_value));
-        BOOST_CHECK(std::isfinite(delta));
-        BOOST_CHECK(std::isfinite(lower_value));
-    }
+    BOOST_CHECK_EQUAL(codes->Dimension(), kRaBitQCodeBytes);
     const auto loaded = SaveAndLoad(quantizer);
     BOOST_CHECK_EQUAL(loaded->GetNumSubvectors(), codes->Dimension());
 
@@ -300,7 +294,7 @@ BOOST_AUTO_TEST_CASE(OfficialScalarRaBitQUsesGlobalQuantizerPath)
     std::remove(kQuantizerFile);
 }
 
-BOOST_AUTO_TEST_CASE(OfficialScalarRaBitQHandlesCentroidVector)
+BOOST_AUTO_TEST_CASE(OfficialCompactRaBitQHandlesCentroidVector)
 {
     ByteArray bytes = ByteArray::Alloc(sizeof(float) * kDimension);
     auto* values = reinterpret_cast<float*>(bytes.Data());
@@ -325,6 +319,32 @@ BOOST_AUTO_TEST_CASE(OfficialScalarRaBitQHandlesCentroidVector)
     std::vector<std::uint8_t> query(quantizer->QuantizeSize());
     quantizer->QuantizeVector(values, query.data());
     BOOST_CHECK(std::isfinite(quantizer->L2Distance(query.data(), code.data())));
+}
+
+BOOST_AUTO_TEST_CASE(OfficialCompactRaBitQStoresRequestedBits)
+{
+    const auto raw = MakeRawVectors();
+    for (int bits = 1; bits <= 8; ++bits) {
+        auto quantizer = std::make_shared<COMMON::RaBitQQuantizer>(
+            kDimension, bits, false);
+        BOOST_REQUIRE(quantizer->Train(raw) == ErrorCode::Success);
+        BOOST_CHECK_EQUAL(
+            quantizer->GetNumSubvectors(),
+            kDimension * bits / 8 + 5 * sizeof(float));
+
+        std::vector<std::uint8_t> code(quantizer->GetNumSubvectors());
+        quantizer->QuantizeVector(raw->GetVector(0), code.data(), false);
+        std::vector<float> reconstructed(kDimension);
+        quantizer->ReconstructVector(code.data(), reconstructed.data());
+        for (float value : reconstructed) {
+            BOOST_CHECK(std::isfinite(value));
+        }
+
+        quantizer->SetEnableADC(true);
+        std::vector<std::uint8_t> query(quantizer->QuantizeSize());
+        quantizer->QuantizeVector(raw->GetVector(1), query.data());
+        BOOST_CHECK(std::isfinite(quantizer->L2Distance(query.data(), code.data())));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/docs/GettingStart.md
+++ b/docs/GettingStart.md
@@ -242,10 +242,109 @@ SearchPostingPageLimit=12
 ### **Global RaBitQ Quantizer**
 
 RaBitQ is a global `IQuantizer`, not a SPANN posting quantizer. Train the
-official scalar model and encode base vectors with `Release/quantizer`, then
+official model and encode base vectors with `Release/quantizer`, then
 use the generated model through `QuantizerFilePath` in the normal SPANN
 workflow. For 128-dimensional SIFT vectors, the encoded `UInt8` vectors use
-`Dim=136` (128 scalar bytes plus two Float reconstruction factors).
+`Dim=68` at 3 bits (48 compact code bytes plus five Float factors).
+
+Train and encode SIFT1M:
+
+```bash
+Release/quantizer \
+  -d 128 -v Float -f XVEC \
+  -i sift1m/sift_base.fvecs \
+  -o sift1m/sift_base.rabitq3.u8bin \
+  -oq sift1m/official_rabitq3_global.bin \
+  -qt RaBitQQuantizer -qd 3 -ts 1000000
+```
+
+The recommended SIFT1M SPANN configuration uses STATIC posting storage:
+
+```ini
+[Base]
+ValueType=UInt8
+DistCalcMethod=L2
+IndexAlgoType=BKT
+Dim=68
+VectorPath=sift1m/sift_base.rabitq3.u8bin
+VectorType=DEFAULT
+VectorSize=1000000
+QueryPath=sift1m/sift_query.fvecs
+QueryType=XVEC
+WarmupPath=sift1m/sift_query.fvecs
+WarmupType=XVEC
+TruthPath=sift1m/sift_groundtruth.ivecs
+TruthType=XVEC
+IndexDirectory=sift1m/spann-rabitq3
+QuantizerFilePath=sift1m/official_rabitq3_global.bin
+
+[SelectHead]
+isExecute=true
+TreeNumber=1
+BKTKmeansK=32
+BKTLeafSize=8
+SamplesNumber=1000
+SaveBKT=false
+SelectThreshold=50
+SplitFactor=6
+SplitThreshold=100
+Ratio=0.16
+NumberOfThreads=24
+BKTLambdaFactor=-1
+
+[BuildHead]
+isExecute=true
+NeighborhoodSize=32
+TPTNumber=32
+TPTLeafSize=2000
+MaxCheck=8192
+MaxCheckForRefineGraph=8192
+RefineIterations=3
+NumberOfThreads=24
+BKTLambdaFactor=-1
+
+[BuildSSDIndex]
+isExecute=true
+BuildSsdIndex=true
+Storage=STATIC
+InternalResultNum=64
+ReplicaCount=8
+PostingPageLimit=12
+NumberOfThreads=24
+MaxCheck=8192
+TmpDir=/tmp/sift1m-spann-rabitq3
+EnableDeltaEncoding=false
+EnablePostingListRearrange=false
+EnableDataCompression=false
+PostingQuantizer=None
+Rerank=0
+EnableADC=true
+
+[SearchSSDIndex]
+isExecute=true
+BuildSsdIndex=false
+QueryCountLimit=10000
+InternalResultNum=32
+SearchThreadNum=1
+HashTableExponent=4
+ResultNum=10
+MaxCheck=2048
+MaxDistRatio=8.0
+SearchPostingPageLimit=12
+```
+
+`SearchSSDIndex.InternalResultNum` is the SPANN equivalent of `nprobe`.
+The recommended value is 32. On SIFT1M with one search thread, the measured
+trade-off after query-factor preprocessing is:
+
+| InternalResultNum | Average latency | P99 latency | QPS | Recall@10 |
+| ---: | ---: | ---: | ---: | ---: |
+| 16 | 0.480 ms | 0.596 ms | 2079 | 0.6401 |
+| 32 | 0.630 ms | 0.761 ms | 1586 | 0.6660 |
+| 64 | 0.811 ms | 0.957 ms | 1231 | 0.6781 |
+
+Adjust `NumberOfThreads` to the build machine. Queries remain raw 128-dimensional
+Float vectors; `Dim=68` describes the encoded base-vector width.
 
 See [`RaBitQ_Global_Quantizer.md`](RaBitQ_Global_Quantizer.md) and
 `Script_AE/iniFile/build_SPANN_sift1m_rabitq3_global.ini`.

--- a/docs/RaBitQ_Global_Quantizer.md
+++ b/docs/RaBitQ_Global_Quantizer.md
@@ -1,12 +1,15 @@
 # Global RaBitQ quantizer
 
-Global RaBitQ is an `IQuantizer` implementation backed by the official scalar
-APIs: `quantize_scalar` encodes vectors and `reconstruct_vec` reconstructs
-them for distance evaluation. It follows the normal global quantizer workflow,
-not the SPANN posting-quantizer workflow.
+Global RaBitQ is an `IQuantizer` implementation backed by the official
+full-code quantizer, compact-code packer, and asymmetric distance estimator.
+Base vectors use `quantize_full_single` and `packing_rabitqplus_code`; ADC
+queries are evaluated with `full_est_dist` and the official SIMD inner-product
+kernel selected for the configured bit width. Query-only distance factors are
+computed once when the ADC query buffer is prepared, not once per candidate.
 
-This is the global scalar API exposed by the official submodule. It does not
-use the separate split-code raw-query posting estimator.
+The SDC compatibility path reconstructs its query code with the official
+`reconstruct_vec` API before invoking the same official asymmetric estimator.
+Online search with `EnableADC=true` does not reconstruct base vectors.
 
 Train the model and encode Float base vectors with `Release/quantizer`:
 
@@ -19,12 +22,17 @@ Release/quantizer \
   -qt RaBitQQuantizer -qd 3 -ts 1000000
 ```
 
-The encoded vectors are `UInt8`. The official scalar layout stores one byte per
-input dimension plus two Float reconstruction factors, so 128-dimensional SIFT
-vectors use `Dim=136`. Configure the encoded base-vector file and
+The encoded vectors are stored in a `UInt8` container, but their code payload is
+packed at the configured bit width. Five Float factors follow each packed code,
+so 128-dimensional 3-bit SIFT vectors use `Dim=68`
+(`128 * 3 / 8 + 5 * sizeof(float)`). Configure the encoded base-vector file and
 `QuantizerFilePath` in the regular SPANN build configuration. Queries remain
-raw Float vectors and are quantized through the loaded global `IQuantizer`.
+raw Float vectors and are prepared through the loaded global `IQuantizer`.
+
+The official compact kernels require AVX2/FMA or AVX512 and pad dimensions to a
+multiple of 64. The current adapter supports the official L2 estimator; cosine
+distance is intentionally unsupported.
 
 `Script_AE/iniFile/build_SPANN_sift1m_rabitq3_global.ini` is the canonical
-SIFT1M example. It uses normal raw postings; do not set `PostingQuantizer` for
-this workflow.
+SIFT1M example. It uses STATIC postings containing the global RaBitQ codes;
+keep `PostingQuantizer=None` because RaBitQ is already the global quantizer.


### PR DESCRIPTION
Use official compact quantization and distance estimation throughout the SPTAG adapter, cache query factors for ADC search, and document the recommended SIFT1M SPANN configuration.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>